### PR TITLE
Convert ControlServer to use a Twisted protocol implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ apt-get update
 
 Before you can install the required Dependencies:
 ````
-apt-get install gstreamer1.0-libav gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools libgstreamer1.0-0 python3 python3-gi gir1.2-gstreamer-1.0
+apt-get install gstreamer1.0-libav gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools libgstreamer1.0-0 python3 python3-gi gir1.2-gstreamer-1.0 python3-twisted-experimental
 ````
 
 For the GUI you'll -- additionally to a gnome-desktop -- need to install the following dependencies:

--- a/voctocore/lib/controlserver.py
+++ b/voctocore/lib/controlserver.py
@@ -1,158 +1,85 @@
 #!/usr/bin/python3
-import socket, logging, traceback
-from queue import Queue
-from gi.repository import GObject
+import logging
+from twisted.internet import protocol
+from twisted.protocols.basic import LineOnlyReceiver
 
 from lib.commands import ControlServerCommands
-from lib.tcpmulticonnection import TCPMultiConnection
 from lib.response import NotifyResponse, OkResponse
 
-class ControlServer(TCPMultiConnection):
-	def __init__(self, pipeline):
-		'''Initialize server and start listening.'''
-		self.log = logging.getLogger('ControlServer')
-		super().__init__(port=9999)
 
-		self.command_queue = Queue()
+class ControlServerProtocol(LineOnlyReceiver):
 
-		self.commands = ControlServerCommands(pipeline)
+	delimiter = b'\n'
 
-		GObject.idle_add(self.on_loop)
+	def connectionMade(self):
+		self.commands = self.factory.commands
+		self.log = self.factory.log
+		self.factory.currentConnections.add(self)
 
-	def on_accepted(self, conn, addr):
-		'''Asynchronous connection listener. Starts a handler for each connection.'''
-		self.log.debug('setting gobject io-watch on connection')
-		GObject.io_add_watch(conn, GObject.IO_IN, self.on_data, [''])
-		GObject.io_add_watch(conn, GObject.IO_OUT, self.on_write)
+	def connectionLost(self, reason=protocol.connectionDone):
+		self.factory.currentConnections.remove(self)
 
-	def on_data(self, conn, _, leftovers, *args):
-		'''Asynchronous connection handler. Pushes data from socket
-		into command queue linewise'''
-		close_after = False
-		try:
-			while True:
-				try:
-					leftovers.append(conn.recv(4096).decode(errors='replace'))
-					if len(leftovers[-1]) == 0:
-						self.log.info("Socket was closed")
-						leftovers.pop()
-						close_after = True
-						break
+	def reply(self, line):
+		"""Send a reply to the client, encoded in UTF-8"""
+		self.sendLine(line.encode('utf-8'))
 
-				except UnicodeDecodeError as e:
-					continue
-		except:
-			pass
-
-		data = "".join(leftovers)
-		del leftovers[:]
-
-		lines = data.split('\n')
-		for line in lines[:-1]:
-			self.log.debug("got line: %r", line)
-
-			line = line.strip()
-			# TODO: move quit to on_loop
-			# 'quit' = remote wants us to close the connection
-			if line == 'quit':
-				self.log.info("Client asked us to close the Connection")
-				self.close_connection(conn)
-				return False
-
-			self.command_queue.put((line, conn))
-
-		if close_after:
-			self.close_connection(conn)
-			return False
-
-		if lines[-1] != '':
-			self.log.debug("remaining %r", lines[-1])
-
-		leftovers.append(lines[-1])
-		return True
-
-	def on_loop(self):
-		'''Command handler. Processes commands in the command queue whenever
-		nothing else is happening (registered as GObject idle callback)'''
-		if self.command_queue.empty():
-			return True
-		line, requestor = self.command_queue.get()
+	def lineReceived(self, line):
+		# Decode to text
+		line = line.decode(errors='replace')
 
 		words = line.split()
 		if len(words) < 1:
-			return True
+			return
 
 		command = words[0]
 		args = words[1:]
 
 		self.log.info("processing command %r with args %s", command, args)
 
+		if command == 'quit':
+			self.transport.loseConnection()
+			return
+
 		response = None
-		try:
-			# deny calling private methods
-			if command[0] == '_':
-				self.log.info('private methods are not callable')
-				raise KeyError()
+		command_function = self.commands.__class__.__dict__.get(command)
+		# deny calling private methods
+		if command.startswith('_'):
+			command_function = None
 
-			command_function = self.commands.__class__.__dict__[command]
-
-		except KeyError as e:
+		if command_function is None:
 			self.log.info("received unknown command %s", command)
-			response = "error unknown command %s\n" % command
+			self.reply("error unknown command %s" % command)
+			return
 
-		else:
-			try:
-				responseObject = command_function(self.commands, *args)
+		try:
+			responseObject = command_function(self.commands, *args)
+		except Exception as e:
+			message = str(e) or "<no message>"
+			self.reply("error %s" % message)
+			return
 
-			except Exception as e:
-				message = str(e) or "<no message>"
-				response = "error %s\n" % message
-
+		if not isinstance(responseObject, list):
+			responseObject = [responseObject]
+		for obj in responseObject:
+			if isinstance(obj, NotifyResponse):
+				for p in self.factory.currentConnections:
+					p.reply(str(obj))
 			else:
-				if isinstance(responseObject, NotifyResponse):
-					responseObject = [ responseObject ]
+				self.reply(str(obj))
 
-				if isinstance(responseObject, list):
-					for obj in responseObject:
-						signal = "%s\n" % str(obj)
-						for conn, queue in self.currentConnections.items():
-							queue.put(signal)
 
-				else:
-					response = "%s\n" % str(responseObject)
+class ControlServer(protocol.ServerFactory):
 
-		finally:
-			if response is not None and requestor in self.currentConnections:
-				self.currentConnections[requestor].put(response)
+	protocol = ControlServerProtocol
 
-		return True
+	def __init__(self, pipeline):
+		'''Initialize server and start listening.'''
+		self.log = logging.getLogger('ControlServer')
+		self.commands = ControlServerCommands(pipeline)
+		self.currentConnections = set()
 
-	def on_write(self, conn, *args):
-		# TODO: on_loop() is not called as soon as there is a writable socket
-		self.on_loop()
+		# Delay importing reactor so we are sure gireactor has
+		# been installed.
+		from twisted.internet import reactor
+		reactor.listenTCP(9999, self, interface="::")
 
-		try:
-			queue = self.currentConnections[conn]
-		except KeyError:
-			return False
-
-		if queue.empty():
-			return True
-
-		message = queue.get()
-		try:
-			conn.send(message.encode())
-		except Exception as e:
-			self.log.warn(e)
-
-		return True
-
-	def notify_all(self, msg):
-		try:
-			words = msg.split()
-			words[-1] = self.commands.encodeSourceName(int(words[-1]))
-			msg = " ".join(words) + '\n'
-			for queue in self.currentConnections.values():
-				queue.put(msg)
-		except Exception as e:
-			self.log.debug("error during notify: %s", e)

--- a/voctocore/lib/controlserver.py
+++ b/voctocore/lib/controlserver.py
@@ -77,9 +77,3 @@ class ControlServer(protocol.ServerFactory):
 		self.log = logging.getLogger('ControlServer')
 		self.commands = ControlServerCommands(pipeline)
 		self.currentConnections = set()
-
-		# Delay importing reactor so we are sure gireactor has
-		# been installed.
-		from twisted.internet import reactor
-		reactor.listenTCP(9999, self, interface="::")
-

--- a/voctocore/runtests.py
+++ b/voctocore/runtests.py
@@ -1,0 +1,6 @@
+#!/usr/bin/python3
+
+import unittest
+
+if __name__ == '__main__':
+    unittest.main('tests')

--- a/voctocore/tests/__init__.py
+++ b/voctocore/tests/__init__.py
@@ -1,0 +1,11 @@
+
+import os
+import unittest
+
+def load_tests(loader, standard_tests, pattern):
+	if pattern is None:
+		pattern = 'test*.py'
+	this_dir = os.path.dirname(__file__)
+	package_tests = loader.discover(start_dir=this_dir, pattern=pattern)
+	standard_tests.addTests(package_tests)
+	return standard_tests

--- a/voctocore/tests/test_controlserver.py
+++ b/voctocore/tests/test_controlserver.py
@@ -1,0 +1,138 @@
+import unittest
+from unittest import mock
+
+from twisted.test import proto_helpers
+
+from lib.controlserver import ControlServer
+from lib.pipeline import Pipeline
+from lib.videomix import CompositeModes, VideoMix
+from lib.audiomix import AudioMix
+from lib.streamblanker import StreamBlanker
+
+
+class ControlServerTests(unittest.TestCase):
+
+	def setUp(self):
+		self.pipeline = mock.Mock(spec=Pipeline)
+		self.pipeline.vmix = mock.Mock(spec=VideoMix)
+		self.pipeline.amix = mock.Mock(spec=AudioMix)
+		self.pipeline.streamblanker = mock.Mock(spec=StreamBlanker)
+		self.factory = ControlServer(self.pipeline)
+
+	def makeConnection(self):
+		transport = proto_helpers.StringTransport()
+		proto = self.factory.buildProtocol(('127.0.0.1', 0))
+		proto.makeConnection(transport)
+		return transport, proto
+
+	def assertResponds(self, command, response):
+		tr1, proto1 = self.makeConnection()
+		tr2, proto2 = self.makeConnection()
+		proto1.dataReceived(command)
+		self.assertEqual(response, tr1.value())
+		# Nothing should be sent to other connections
+		self.assertEqual(b'', tr2.value())
+
+	def assertNotifies(self, command, response):
+		tr1, proto1 = self.makeConnection()
+		tr2, proto2 = self.makeConnection()
+		proto1.dataReceived(command)
+		self.assertEqual(response, tr1.value())
+		self.assertEqual(response, tr2.value())
+
+	def test_quit(self):
+		tr, proto = self.makeConnection()
+		proto.dataReceived(b'quit\n')
+		self.assertTrue(tr.disconnecting)
+
+	def test_bad_command(self):
+		self.assertResponds(b'no_such_command\n',
+				    b'error unknown command no_such_command\n')
+
+	def test_private_method(self):
+		self.assertResponds(b'__init__ foo\n',
+				    b'error unknown command __init__\n')
+
+	def test_message(self):
+		self.assertNotifies(b'message hello world\n',
+				    b'message hello world\n')
+
+	def test_get_video(self):
+		self.pipeline.vmix.getVideoSourceA.return_value = 0
+		self.pipeline.vmix.getVideoSourceB.return_value = 1
+		tr, proto = self.makeConnection()
+		self.assertResponds(b'get_video\n',
+				    b'video_status cam1 cam2\n')
+
+	def test_set_video_a(self):
+		self.pipeline.vmix.getVideoSourceA.return_value = 1
+		self.pipeline.vmix.getVideoSourceB.return_value = 0
+		self.assertNotifies(b'set_video_a cam2\n',
+				    b'video_status cam2 cam1\n')
+		self.pipeline.vmix.setVideoSourceA.assert_called_once_with(1)
+
+	def test_set_video_b(self):
+		self.pipeline.vmix.getVideoSourceA.return_value = 1
+		self.pipeline.vmix.getVideoSourceB.return_value = 0
+		self.assertNotifies(b'set_video_b cam1\n',
+				    b'video_status cam2 cam1\n')
+		self.pipeline.vmix.setVideoSourceB.assert_called_once_with(0)
+
+	def test_get_audio(self):
+		self.pipeline.amix.getAudioSource.return_value = 0
+		self.assertResponds(b'get_audio\n',
+				    b'audio_status cam1\n')
+
+	def test_set_audio(self):
+		self.pipeline.amix.getAudioSource.return_value = 1
+		self.assertNotifies(b'set_audio cam2\n',
+				    b'audio_status cam2\n')
+		self.pipeline.amix.setAudioSource.assert_called_once_with(1)
+
+	def test_get_composite_mode(self):
+		self.pipeline.vmix.getCompositeMode.return_value = CompositeModes.picture_in_picture
+		self.assertResponds(b'get_composite_mode\n',
+				    b'composite_mode picture_in_picture\n')
+
+	def test_set_composite_mode(self):
+		self.pipeline.vmix.getCompositeMode.return_value = CompositeModes.picture_in_picture
+		self.assertNotifies(b'set_composite_mode picture_in_picture\n',
+				    b'composite_mode picture_in_picture\n')
+		self.pipeline.vmix.setCompositeMode.assert_called_once_with(CompositeModes.picture_in_picture)
+
+	def test_set_videos_and_composite(self):
+		self.pipeline.vmix.getVideoSourceA.return_value = 1
+		self.pipeline.vmix.getVideoSourceB.return_value = 0
+		self.pipeline.vmix.getCompositeMode.return_value = CompositeModes.picture_in_picture
+		self.assertNotifies(b'set_videos_and_composite cam2 cam1 picture_in_picture\n',
+				    b'composite_mode picture_in_picture\n' +
+				    b'video_status cam2 cam1\n')
+		self.pipeline.vmix.setVideoSourceA.assert_called_once_with(1)
+		self.pipeline.vmix.setVideoSourceB.assert_called_once_with(0)
+		self.pipeline.vmix.setCompositeMode.assert_called_once_with(CompositeModes.picture_in_picture)
+
+	def test_get_stream_status(self):
+		self.pipeline.streamblanker.blankSource = None
+		self.assertResponds(b'get_stream_status\n',
+				    b'stream_status live\n')
+
+		self.pipeline.streamblanker.blankSource = 0
+		self.assertResponds(b'get_stream_status\n',
+				    b'stream_status blank pause\n')
+
+	def test_set_stream_blank(self):
+		self.pipeline.streamblanker.blankSource = 0
+		self.assertNotifies(b'set_stream_blank pause\n',
+				    b'stream_status blank pause\n')
+		self.pipeline.streamblanker.setBlankSource.assert_called_once_with(0)
+
+	def test_set_stream_live(self):
+		self.pipeline.streamblanker.blankSource = None
+		self.assertNotifies(b'set_stream_live\n',
+				    b'stream_status live\n')
+		self.pipeline.streamblanker.setBlankSource.assert_called_once_with(None)
+
+	def test_get_config(self):
+		tr, proto = self.makeConnection()
+		proto.dataReceived(b'get_config\n')
+		self.assertRegex(tr.value(), b'server_config .*\n')

--- a/voctocore/voctocore.py
+++ b/voctocore/voctocore.py
@@ -7,6 +7,7 @@ from gi.repository import Gst, GObject
 
 from twisted.internet import gireactor
 gireactor.install()
+from twisted.internet import reactor
 
 # check min-version
 minGst = (1, 5)
@@ -41,6 +42,8 @@ class Voctocore(object):
 
 		self.log.debug('creating ControlServer')
 		self.controlserver = ControlServer(self.pipeline)
+                reactor.listenTCP(9999, self.controlserver, interface="::")
+
 
 	def run(self):
 		self.log.info('running GObject-MainLoop')

--- a/voctocore/voctocore.py
+++ b/voctocore/voctocore.py
@@ -5,6 +5,9 @@ import gi, signal, logging, sys
 gi.require_version('Gst', '1.0')
 from gi.repository import Gst, GObject
 
+from twisted.internet import gireactor
+gireactor.install()
+
 # check min-version
 minGst = (1, 5)
 minPy = (3, 0)


### PR DESCRIPTION
This is a fix for bug #19.  On Ubuntu or Debian systems, you'll need to install the `python3-twisted-experimental` package to get things working (the "experimental" part of the name seems to be due to not everything having been ported from Python 2).

Without this patch, an idle voctocore instance with no inputs being fed and nothing being read from it was using approximately 3 CPU cores.  With this patch it is down to approximately 2 cores.

While converting the code, I tried to flatten some of the logic that is now in the lineReceived method to make it a bit more readable.  I'm not convinced the old logic was correct, so in the new version it explicitly only broadcasts responses if they are NotifyResponse instances.

I tested the changes out using telnet to localhost and ip6-localhost, and checked that notify responses got sent to all clients while other responses didn't.  The GUI also seems to function as normal with the changes.