### PR TITLE
Add single Dockerfile for quickstart of new users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+## re-build:
+# docker tag bjoernr/voctocore:latest bjoernr/voctocore:old; docker build -t bjoernr/voctocore ./voctocore-docker && docker rmi bjoernr/voctocore:old
+## build:
+# docker build -t bjoernr/voctocore ./voctocore-docker
+## run:
+# docker run -it --rm bjoernr/voctocore
+# docker run -it --rm -v /some/dir:/video
+#	-p 9999:9999 -p 10000:10000 -p 10001:10001 -p 10002:10002 -p 11000:11000 -p 12000:12000 \
+#	-p 13000:13000 -p 13001:13001 -p 13002:13002 -p 14000:14000 -p 15000:15000 -p 16000:16000 \
+#	-p 17000:17000 -p 17001:17001 -p 17002:17002 -p 18000:18000 --name=voctocore bjoernr/voctocore
+
+FROM ubuntu:wily
+
+MAINTAINER Bjoern Riemer <bjoern.riemer@web.de>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV uid 1000
+ENV gid 1000
+
+RUN useradd -m voc
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+		gstreamer1.0-plugins-ugly gstreamer1.0-tools libgstreamer1.0-0 python3 python3-gi gir1.2-gstreamer-1.0 \
+	&& apt-get install -y git wget \
+	&& apt-get clean
+
+# stuff for the GUI
+RUN apt-get update \
+	&& apt-get install -y gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0 gir1.2-gtk-3.0 \
+	ffmpeg \
+	&& apt-get clean
+
+RUN wget -q https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64 -O /bin/gosu && chmod +x /bin/gosu
+#RUN cd /opt && git clone https://github.com/voc/voctomix.git
+RUN mkdir -p /opt/voctomix
+
+EXPOSE 9998 9999 10000 10001 10002 11000 12000 13000 13001 13002 14000 15000 16000 17000 17001 17002 18000 
+VOLUME /video
+
+WORKDIR /opt/voctomix
+COPY . /opt/voctomix/
+
+RUN sed -i 's/localhost/corehost/g' voctogui/default-config.ini \
+	&& find /opt/voctomix/example-scripts/ -type f -exec sed -i 's/localhost/corehost/g' {} \;
+
+ENTRYPOINT ["/opt/voctomix/docker-ep.sh"]
+CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,27 @@
+## initial build:
+# docker build -t local/voctomix .
 ## re-build:
 # docker tag local/voctomix:latest local/voctomix:old; docker build -t local/voctomix . && docker rmi local/voctomix:old
-## build:
-# docker build -t bjoernr/voctomix .
+#
 ## run:
-# docker run -it --rm bjoernr/voctocore help
+# docker run -it --rm local/voctocore help
+#
 ## core:
 # docker run -it --rm -v /some/dir:/video
 #	-p 9999:9999 -p 10000:10000 -p 10001:10001 -p 10002:10002 -p 11000:11000 -p 12000:12000 \
 #	-p 13000:13000 -p 13001:13001 -p 13002:13002 -p 14000:14000 -p 15000:15000 -p 16000:16000 \
-#	-p 17000:17000 -p 17001:17001 -p 17002:17002 -p 18000:18000 --name=voctocore bjoernr/voctomix core
+#	-p 17000:17000 -p 17001:17001 -p 17002:17002 -p 18000:18000 --name=voctocore local/voctomix core
+#
+## test sources 
+# docker run -it --rm --name=cam1 --link=voctocore:corehost local/voctomix ./gstreamer/source-videotestsrc-as-cam1.sh
+# docker run -it --rm --name=bg --link=voctocore:corehost local/voctomix gstreamer/source-videotestsrc-as-background-loop.sh#
+#
 ## gui
 ## gui will connect to "corehost": corehost is aliased to container "voctocore"
-# docker run -it --rm --env=gid=$(id -g) --env=uid=$(id -u) --env=DISPLAY=$DISPLAY --link=voctocore:corehost \
-#   -v /tmp/.X11-unix:/tmp/.X11-unix -v /tmp/.docker.xauth:/tmp/. bjoernr/voctomix gui
-## scripts
-# docker run -it --rm bjoernr/voctomix --link=voctocore:corehost bjoernr/voctomix gstreamer/source-videotestsrc-as-background-loop.sh
+# xhost +local:$(id -un)
+# docker run -it --rm --name=gui --env=gid=$(id -g) --env=uid=$(id -u) --env=DISPLAY=:0 --link=voctocore:corehost \
+#  -v /tmp/vocto/configgui.ini:/opt/voctomix/voctogui/config.ini -v /tmp/.X11-unix:/tmp/.X11-unix -v /tmp/.docker.xauth:/tmp/.docker.xauth local/voctomix gui
+
 
 FROM ubuntu:wily
 
@@ -28,20 +35,13 @@ ENV gid 1000
 RUN useradd -m voc
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
-		gstreamer1.0-plugins-ugly gstreamer1.0-tools libgstreamer1.0-0 python3 python3-gi gir1.2-gstreamer-1.0 \
-	&& apt-get install -y git wget \
-	&& apt-get clean
-
-# stuff for the GUI
-RUN apt-get update \
-	&& apt-get install -y gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0 gir1.2-gtk-3.0 \
-	ffmpeg \
+	&& apt-get install -y gstreamer1.0-plugins-good vim-tiny wget \
+	&& apt-get install -y --no-install-recommends gstreamer1.0-tools libgstreamer1.0-0 python3 python3-gi gir1.2-gstreamer-1.0 gstreamer1.0-plugins-bad \
+	&& apt-get install -y gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0 gir1.2-gtk-3.0 gstreamer1.0-x ffmpeg python3-gi-cairo \
 	&& apt-get clean
 
 RUN wget -q https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64 -O /bin/gosu && chmod +x /bin/gosu
-#RUN cd /opt && git clone https://github.com/voc/voctomix.git
+
 RUN mkdir -p /opt/voctomix
 
 EXPOSE 9998 9999 10000 10001 10002 11000 12000 13000 13001 13002 14000 15000 16000 17000 17001 17002 18000 
@@ -49,9 +49,11 @@ VOLUME /video
 
 WORKDIR /opt/voctomix
 COPY . /opt/voctomix/
+COPY docker-ep.sh /opt/voctomix/
 
-RUN sed -i 's/localhost/corehost/g' voctogui/default-config.ini \
-	&& find /opt/voctomix/example-scripts/ -type f -exec sed -i 's/localhost/corehost/g' {} \;
+RUN sed -i 's/localhost/corehost/g' voctogui/default-config.ini ;\
+	sed -i 's/system=gl/system=xv/g' voctogui/default-config.ini ;\
+	find /opt/voctomix/example-scripts/ -type f -exec sed -i 's/localhost/corehost/g' {} \;
 
 ENTRYPOINT ["/opt/voctomix/docker-ep.sh"]
 CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
 ## re-build:
-# docker tag bjoernr/voctocore:latest bjoernr/voctocore:old; docker build -t bjoernr/voctocore ./voctocore-docker && docker rmi bjoernr/voctocore:old
+# docker tag local/voctomix:latest local/voctomix:old; docker build -t local/voctomix . && docker rmi local/voctomix:old
 ## build:
-# docker build -t bjoernr/voctocore ./voctocore-docker
+# docker build -t bjoernr/voctomix .
 ## run:
-# docker run -it --rm bjoernr/voctocore
+# docker run -it --rm bjoernr/voctocore help
+## core:
 # docker run -it --rm -v /some/dir:/video
 #	-p 9999:9999 -p 10000:10000 -p 10001:10001 -p 10002:10002 -p 11000:11000 -p 12000:12000 \
 #	-p 13000:13000 -p 13001:13001 -p 13002:13002 -p 14000:14000 -p 15000:15000 -p 16000:16000 \
-#	-p 17000:17000 -p 17001:17001 -p 17002:17002 -p 18000:18000 --name=voctocore bjoernr/voctocore
+#	-p 17000:17000 -p 17001:17001 -p 17002:17002 -p 18000:18000 --name=voctocore bjoernr/voctomix core
+## gui
+## gui will connect to "corehost": corehost is aliased to container "voctocore"
+# docker run -it --rm --env=gid=$(id -g) --env=uid=$(id -u) --env=DISPLAY=$DISPLAY --link=voctocore:corehost \
+#   -v /tmp/.X11-unix:/tmp/.X11-unix -v /tmp/.docker.xauth:/tmp/. bjoernr/voctomix gui
+## scripts
+# docker run -it --rm bjoernr/voctomix --link=voctocore:corehost bjoernr/voctomix gstreamer/source-videotestsrc-as-background-loop.sh
 
 FROM ubuntu:wily
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 #	-p 17000:17000 -p 17001:17001 -p 17002:17002 -p 18000:18000 --name=voctocore local/voctomix core
 #
 ## test sources 
-# docker run -it --rm --name=cam1 --link=voctocore:corehost local/voctomix ./gstreamer/source-videotestsrc-as-cam1.sh
+# docker run -it --rm --name=cam1 --link=voctocore:corehost local/voctomix gstreamer/source-videotestsrc-as-cam1.sh
 # docker run -it --rm --name=bg --link=voctocore:corehost local/voctomix gstreamer/source-videotestsrc-as-background-loop.sh#
 #
 ## gui

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Voctomix Project consists of three parts:
  - Voctotools (tbd.), a Collection of Tools and Examples on how to talk to the core-process, feeding and receiving video-streams
 
 ## Installation
-Voctomix requires a fairly recent Version of GStreamer (at least 1.5, though we recommend 1.6 and later). This is natively present on [Debian Sid](https://packages.debian.org/sid/libgstreamer1.0-0) and [Ubuntu Wily](http://packages.ubuntu.com/wily/libgstreamer1.0-0). On these Systems it should run out of the Box and we recommend using one of them.
+Voctomix requires a fairly recent Version of GStreamer (at least 1.5, though we recommend 1.6 and later). This is natively present on [Debian Sid](https://packages.debian.org/sid/libgstreamer1.0-0) and [Ubuntu Wily](http://packages.ubuntu.com/wily/libgstreamer1.0-0). On these Systems it should run out of the Box and we recommend using one of them. A [Docker](http://www.docker.com) image that uses Ubuntu Wily as a base is bundled with Vocomix. Please refer to the seperate [readme](./README_DOCKER.md) how to use the Docker image.
 
 Install the required Dependencies:
 ````

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -25,7 +25,7 @@ docker run --rm -it --name=voctocore local/voctomix core
 ```
 ### Source example scripts
 ```
-docker run -it --rm --name=cam1 --link=voctocore:corehost local/voctomix ./gstreamer/source-videotestsrc-as-cam1.sh
+docker run -it --rm --name=cam1 --link=voctocore:corehost local/voctomix gstreamer/source-videotestsrc-as-cam1.sh
 docker run -it --rm --name=bg --link=voctocore:corehost local/voctomix gstreamer/source-videotestsrc-as-background-loop.sh
 ```
 

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -1,0 +1,38 @@
+# HowTo use the Docker version of Voctomix
+## build the docker container locally
+- checkout branch: 
+```
+git checkout quickstart-docker
+```
+- build docker
+```
+docker build -t local/voctomix .
+```
+- rebuild docker after changes
+```
+docker tag local/voctomix:latest local/voctomix:old; \
+docker build -t local/voctomix . && docker rmi local/voctomix:old
+```
+
+## Test the docker
+the entrypoint script of the container provides some commands to ease the startup of the individual components. get a list by running
+```docker run --rm -it --name=voctocore local/voctomix core```
+
+## Run the components
+### CORE
+```
+docker run --rm -it --name=voctocore local/voctomix core
+```
+### Source example scripts
+```
+docker run -it --rm --name=cam1 --link=voctocore:corehost local/voctomix ./gstreamer/source-videotestsrc-as-cam1.sh
+docker run -it --rm --name=bg --link=voctocore:corehost local/voctomix gstreamer/source-videotestsrc-as-background-loop.sh
+```
+
+### GUI
+to run the GUI in a docker the docker user needs access to the local X server. This is done by sharing the ```/tmp/.X11-unix``` socket with the container. Depending on your X11 setup you have to allow access to the X-Server session by running: ```xhost +local:$(id -un)```
+The example below maps the local voctogui config file ```/tmp/vocto/configgui.ini``` into the container. Please create and change this file to change the voctogui configuration.
+```
+docker run -it --rm --name=gui --env=gid=$(id -g) --env=uid=$(id -u) --env=DISPLAY=:0 --link=voctocore:corehost \
+  -v /tmp/vocto/configgui.ini:/opt/voctomix/voctogui/config.ini -v /tmp/.X11-unix:/tmp/.X11-unix -v /tmp/.docker.xauth:/tmp/.docker.xauth local/voctomix gui
+```

--- a/docker-ep.sh
+++ b/docker-ep.sh
@@ -58,6 +58,7 @@ function usage() {
 	echo "core 			- starts voctomix gore"
 	echo "gui 			- starts the voctomix GUI"
 	echo "examples	 	- lists the example scripts"
+	echo "bash			- run interactive bash"
 	echo "scriptname.py - starts the example script named 'scriptname.py' "
 }
 
@@ -73,6 +74,10 @@ case $1 in
 		;;
 	core )
 		startCore
+		;;
+	bash )
+		shift 
+		bash $@
 		;;
 	* )
 		runExample $1

--- a/docker-ep.sh
+++ b/docker-ep.sh
@@ -22,6 +22,7 @@ if [ ! -z $gid ] && [ ! -z $uid ]; then
 fi
 
 function startCore() {
+	echo "Starting Voctomix CORE"
 	if [ -x /bin/gosu ]; then
 		gosu voc /opt/voctomix/voctocore/voctocore.py -v
 	else
@@ -35,8 +36,9 @@ function isVideoMounted() {
 }
 
 function startGui() {
+	echo "Starting Voctomix GUI..."
 	if [ -x /bin/gosu ]; then
-		gosu voc /opt/voctomix/voctocore/voctocore.py -v
+		gosu voc /opt/voctomix/voctogui/voctogui.py -v
 	else
 		echo "no gosu found..."
 		exec su -l -c "/opt/voctomix/voctogui/voctogui.py -v" voc

--- a/docker-ep.sh
+++ b/docker-ep.sh
@@ -2,16 +2,23 @@
 ##
 ## entrypoint for the docker images
 
-groupmod -g $gid voc
-usermod -u $uid -g $gid voc
+if [ ! -f /.dockerenv ] && [ ! -f /.dockerinit ]; then
+	echo "WARNING: this scrip should be only runed inside docker!!"
+	exit 1
+fi
 
-# check if homedir is mounted
-if grep -q '/home/voc' /proc/mounts; then
-	# homedir is mounted into the docker so don't touch the ownership of the files
-	true
-else
-	# fixup for changed uid and gid
-	chown -R voc:voc /home/voc
+if [ ! -z $gid ] && [ ! -z $uid ]; then
+	groupmod -g $gid voc
+	usermod -u $uid -g $gid voc
+
+	# check if homedir is mounted
+	if grep -q '/home/voc' /proc/mounts; then
+		# homedir is mounted into the docker so don't touch the ownership of the files
+		true
+	else
+		# fixup for changed uid and gid
+		chown -R voc:voc /home/voc
+	fi
 fi
 
 function startCore() {
@@ -61,6 +68,11 @@ function usage() {
 	echo "bash			- run interactive bash"
 	echo "scriptname.py - starts the example script named 'scriptname.py' "
 }
+
+if [ -z $1 ]; then
+	usage
+	exit
+fi
 
 case $1 in
 	help )

--- a/docker-ep.sh
+++ b/docker-ep.sh
@@ -3,7 +3,7 @@
 ## entrypoint for the docker images
 
 if [ ! -f /.dockerenv ] && [ ! -f /.dockerinit ]; then
-	echo "WARNING: this scrip should be only runed inside docker!!"
+	echo "WARNING: this script should be only run inside docker!!"
 	exit 1
 fi
 

--- a/docker-ep.sh
+++ b/docker-ep.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+##
+## entrypoint for the docker images
+
+groupmod -g $gid voc
+usermod -u $uid -g $gid voc
+
+# check if homedir is mounted
+if grep -q '/home/voc' /proc/mounts; then
+	# homedir is mounted into the docker so don't touch the ownership of the files
+	true
+else
+	# fixup for changed uid and gid
+	chown -R voc:voc /home/voc
+fi
+
+function startCore() {
+	if [ -x /bin/gosu ]; then
+		gosu voc /opt/voctomix/voctocore/voctocore.py -v
+	else
+		echo "no gosu found..."
+		exec su -l -c "/opt/voctomix/voctocore/voctocore.py -v" voc
+	fi
+}
+
+function isVideoMounted() {
+	return grep -q '/video' /proc/mounts
+}
+
+function startGui() {
+	if [ -x /bin/gosu ]; then
+		gosu voc /opt/voctomix/voctocore/voctocore.py -v
+	else
+		echo "no gosu found..."
+		exec su -l -c "/opt/voctomix/voctogui/voctogui.py -v" voc
+	fi
+}
+
+function listExamples() {
+	cd example-scripts/
+	find  -type f
+}
+
+function runExample() {
+	if [ -z $1 ]; then 
+		echo "no valid example! "
+	fi
+	FILENAME="example-scripts/$1"
+	if [ -f ${FILENAME} ]; then
+		echo "Running: ${FILENAME}"
+		${FILENAME}
+	fi
+}
+
+function usage() {
+	echo "Usage: $0 <cmd>"
+	echo "help			- this text"
+	echo "core 			- starts voctomix gore"
+	echo "gui 			- starts the voctomix GUI"
+	echo "examples	 	- lists the example scripts"
+	echo "scriptname.py - starts the example script named 'scriptname.py' "
+}
+
+case $1 in
+	help )
+		usage
+		;;
+	examples )
+		listExamples
+		;;
+	gui )
+		startGui
+		;;
+	core )
+		startCore
+		;;
+	* )
+		runExample $1
+		;;
+esac


### PR DESCRIPTION
This pull adds a Dockerfile and a entrypoint scriptto the root of the repository. When these files are present the repository could easily be added to the docker hub as an autobuild project. 
On every change to voctomix git the docker hub will rebuild the public docker container. 
This container can be used to quickly setup a working voctomix "cluster" (core, gui and source-scripts)