### PR TITLE
Experiment with vaapi for the Preview-Encoders

### DIFF
--- a/voctocore/default-config.ini
+++ b/voctocore/default-config.ini
@@ -62,9 +62,13 @@ mix_out=10000
 enabled=false
 deinterlace=false
 
+; use vaapi to encode the previews, can be h264, mpeg2 or jpeg
+; not all encoders are available on all CPUs
+;vaapi=h264
+
 ; default to mix-videocaps, only applicable if enabled=true
 ; you can change the framerate and the width/height, but nothing else
-videocaps=video/x-raw,width=1024,height=576,framerate=25/1
+;videocaps=video/x-raw,width=1024,height=576,framerate=25/1
 
 [stream-blanker]
 enabled=true

--- a/voctocore/default-config.ini
+++ b/voctocore/default-config.ini
@@ -62,7 +62,7 @@ mix_out=10000
 enabled=false
 deinterlace=false
 
-; use vaapi to encode the previews, can be h264, mpeg2 or jpeg
+; use vaapi to encode the previews, can be h264, mpeg2 or jpeg (BUT ONLY h264 IS TESTED)
 ; not all encoders are available on all CPUs
 ;vaapi=h264
 

--- a/voctocore/lib/avpreviewoutput.py
+++ b/voctocore/lib/avpreviewoutput.py
@@ -27,12 +27,22 @@ class AVPreviewOutput(TCPMultiConnection):
         if Config.has_option('previews', 'vaapi'):
             try:
                 encoder = Config.get('previews', 'vaapi')
-                encoders = {
-                    'h264': 'vaapih264enc rate-control=cqp init-qp=23'
-                            'cabac=false max-bframes=0 keyframe-period=60',
-                    'jpeg': 'vaapijpegenc quality=90 keyframe-period=0',
-                    'mpeg2': 'vaapimpeg2enc keyframe-period=60',
-                }
+                if Gst.version() < (1, 8):
+                    encoders = {
+                        'h264': 'vaapiencode_h264 rate-control=cqp init-qp=23'
+                                'cabac=false max-bframes=0 keyframe-period=60',
+                        'jpeg': 'vaapiencode_jpeg quality=90'
+                                'keyframe-period=0',
+                        'mpeg2': 'vaapiencode_mpeg2 keyframe-period=60',
+                    }
+                else:
+                    encoders = {
+                        'h264': 'vaapih264enc rate-control=cqp init-qp=23'
+                                'cabac=false max-bframes=0 keyframe-period=60',
+                        'jpeg': 'vaapijpegenc quality=90'
+                                'keyframe-period=0',
+                        'mpeg2': 'vaapimpeg2enc keyframe-period=60',
+                    }
                 venc = encoders[encoder]
             except Exception as e:
                 self.log.error(e)

--- a/voctocore/lib/avpreviewoutput.py
+++ b/voctocore/lib/avpreviewoutput.py
@@ -29,7 +29,7 @@ class AVPreviewOutput(TCPMultiConnection):
                 encoder = Config.get('previews', 'vaapi')
                 if Gst.version() < (1, 8):
                     encoders = {
-                        'h264': 'vaapiencode_h264 rate-control=cqp init-qp=23'
+                        'h264': 'vaapiencode_h264 rate-control=cqp init-qp=23 '
                                 'cabac=false max-bframes=0 keyframe-period=60',
                         'jpeg': 'vaapiencode_jpeg quality=90'
                                 'keyframe-period=0',
@@ -37,7 +37,7 @@ class AVPreviewOutput(TCPMultiConnection):
                     }
                 else:
                     encoders = {
-                        'h264': 'vaapih264enc rate-control=cqp init-qp=23'
+                        'h264': 'vaapih264enc rate-control=cqp init-qp=23 '
                                 'cabac=false max-bframes=0 keyframe-period=60',
                         'jpeg': 'vaapijpegenc quality=90'
                                 'keyframe-period=0',

--- a/voctocore/lib/avpreviewoutput.py
+++ b/voctocore/lib/avpreviewoutput.py
@@ -23,6 +23,18 @@ class AVPreviewOutput(TCPMultiConnection):
         if Config.getboolean('previews', 'deinterlace'):
             deinterlace = "deinterlace mode=interlaced !"
 
+		venc = 'jpegenc quality=90'
+		try:
+			encoder = Config.get('previews', 'vaapi')
+			encoders = {
+				'h264': 'vaapih264enc',
+				'jpeg': 'vaapijpegenc',
+				'mpeg2': 'vaapimpeg2enc',
+			}
+			venc = encoders[encoder]
+		except Exception as e:
+			self.log.error(e)
+
         pipeline = """
             intervideosrc channel=video_{channel} !
             {vcaps_in} !
@@ -30,7 +42,7 @@ class AVPreviewOutput(TCPMultiConnection):
             videoscale !
             videorate !
             {vcaps_out} !
-            jpegenc quality=90 !
+			{venc} !
             queue !
             mux.
 
@@ -54,7 +66,8 @@ class AVPreviewOutput(TCPMultiConnection):
             acaps=Config.get('mix', 'audiocaps'),
             vcaps_in=Config.get('mix', 'videocaps'),
             vcaps_out=vcaps_out,
-            deinterlace=deinterlace
+			deinterlace=deinterlace,
+			venc=venc
         )
 
         self.log.debug('Creating Output-Pipeline:\n%s', pipeline)

--- a/voctocore/lib/avpreviewoutput.py
+++ b/voctocore/lib/avpreviewoutput.py
@@ -27,9 +27,9 @@ class AVPreviewOutput(TCPMultiConnection):
 		try:
 			encoder = Config.get('previews', 'vaapi')
 			encoders = {
-				'h264': 'vaapih264enc',
-				'jpeg': 'vaapijpegenc',
-				'mpeg2': 'vaapimpeg2enc',
+				'h264': 'vaapih264enc rate-control=cqp init-qp=23 cabac=false max-bframes=0 keyframe-period=60',
+				'jpeg': 'vaapijpegenc quality=90 keyframe-period=0',
+				'mpeg2': 'vaapimpeg2enc keyframe-period=60',
 			}
 			venc = encoders[encoder]
 		except Exception as e:

--- a/voctocore/lib/avpreviewoutput.py
+++ b/voctocore/lib/avpreviewoutput.py
@@ -29,16 +29,16 @@ class AVPreviewOutput(TCPMultiConnection):
                 encoder = Config.get('previews', 'vaapi')
                 if Gst.version() < (1, 8):
                     encoders = {
-                        'h264': 'vaapiencode_h264 rate-control=cqp init-qp=23 '
-                                'cabac=false max-bframes=0 keyframe-period=60',
+                        'h264': 'vaapiencode_h264 rate-control=cqp init-qp=10 '
+                                'max-bframes=0 keyframe-period=60',
                         'jpeg': 'vaapiencode_jpeg quality=90'
                                 'keyframe-period=0',
                         'mpeg2': 'vaapiencode_mpeg2 keyframe-period=60',
                     }
                 else:
                     encoders = {
-                        'h264': 'vaapih264enc rate-control=cqp init-qp=23 '
-                                'cabac=false max-bframes=0 keyframe-period=60',
+                        'h264': 'vaapih264enc rate-control=cqp init-qp=10 '
+                                'max-bframes=0 keyframe-period=60',
                         'jpeg': 'vaapijpegenc quality=90'
                                 'keyframe-period=0',
                         'mpeg2': 'vaapimpeg2enc keyframe-period=60',

--- a/voctocore/lib/avpreviewoutput.py
+++ b/voctocore/lib/avpreviewoutput.py
@@ -24,6 +24,7 @@ class AVPreviewOutput(TCPMultiConnection):
             deinterlace = "deinterlace mode=interlaced !"
 
 		venc = 'jpegenc quality=90'
+		if Config.has_option('previews', 'vaapi'):
 		try:
 			encoder = Config.get('previews', 'vaapi')
 			encoders = {

--- a/voctocore/lib/avpreviewoutput.py
+++ b/voctocore/lib/avpreviewoutput.py
@@ -23,18 +23,19 @@ class AVPreviewOutput(TCPMultiConnection):
         if Config.getboolean('previews', 'deinterlace'):
             deinterlace = "deinterlace mode=interlaced !"
 
-		venc = 'jpegenc quality=90'
-		if Config.has_option('previews', 'vaapi'):
-		try:
-			encoder = Config.get('previews', 'vaapi')
-			encoders = {
-				'h264': 'vaapih264enc rate-control=cqp init-qp=23 cabac=false max-bframes=0 keyframe-period=60',
-				'jpeg': 'vaapijpegenc quality=90 keyframe-period=0',
-				'mpeg2': 'vaapimpeg2enc keyframe-period=60',
-			}
-			venc = encoders[encoder]
-		except Exception as e:
-			self.log.error(e)
+        venc = 'jpegenc quality=90'
+        if Config.has_option('previews', 'vaapi'):
+            try:
+                encoder = Config.get('previews', 'vaapi')
+                encoders = {
+                    'h264': 'vaapih264enc rate-control=cqp init-qp=23'
+                            'cabac=false max-bframes=0 keyframe-period=60',
+                    'jpeg': 'vaapijpegenc quality=90 keyframe-period=0',
+                    'mpeg2': 'vaapimpeg2enc keyframe-period=60',
+                }
+                venc = encoders[encoder]
+            except Exception as e:
+                self.log.error(e)
 
         pipeline = """
             intervideosrc channel=video_{channel} !
@@ -43,7 +44,7 @@ class AVPreviewOutput(TCPMultiConnection):
             videoscale !
             videorate !
             {vcaps_out} !
-			{venc} !
+            {venc} !
             queue !
             mux.
 
@@ -67,8 +68,8 @@ class AVPreviewOutput(TCPMultiConnection):
             acaps=Config.get('mix', 'audiocaps'),
             vcaps_in=Config.get('mix', 'videocaps'),
             vcaps_out=vcaps_out,
-			deinterlace=deinterlace,
-			venc=venc
+            deinterlace=deinterlace,
+            venc=venc
         )
 
         self.log.debug('Creating Output-Pipeline:\n%s', pipeline)

--- a/voctogui/lib/videodisplay.py
+++ b/voctogui/lib/videodisplay.py
@@ -16,34 +16,34 @@ class VideoDisplay(object):
         self.drawing_area = drawing_area
         self.level_callback = level_callback
 
-		if Config.has_option('previews', 'videocaps'):
-			previewcaps = Config.get('previews', 'videocaps')
-		else:
-			previewcaps = Config.get('mix', 'videocaps')
+        if Config.has_option('previews', 'videocaps'):
+            previewcaps = Config.get('previews', 'videocaps')
+        else:
+            previewcaps = Config.get('mix', 'videocaps')
 
         use_previews = (Config.getboolean('previews', 'enabled') and
                         Config.getboolean('previews', 'use'))
 
         # Preview-Ports are Raw-Ports + 1000
         if use_previews:
-			self.log.info('using endoded previews instead of raw-video for gui')
+            self.log.info('using encoded previews instead of raw-video')
             port += 1000
 
-			vdec = 'image/jpeg ! jpegdec'
-			if Config.has_option('previews', 'vaapi'):
-				try:
-					decoder = Config.get('previews', 'vaapi')
-					decoders = {
-						'h264': 'video/x-h264 ! avdec_h264',
-						'jpeg': 'image/jpeg ! jpegdec',
-						'mpeg2': 'video/mpeg,mpegversion=2 ! mpeg2dec'
-					}
-					vdec = decoders[decoder]
-				except Exception as e:
-					self.log.error(e)
+            vdec = 'image/jpeg ! jpegdec'
+            if Config.has_option('previews', 'vaapi'):
+                try:
+                    decoder = Config.get('previews', 'vaapi')
+                    decoders = {
+                        'h264': 'video/x-h264 ! avdec_h264',
+                        'jpeg': 'image/jpeg ! jpegdec',
+                        'mpeg2': 'video/mpeg,mpegversion=2 ! mpeg2dec'
+                    }
+                    vdec = decoders[decoder]
+                except Exception as e:
+                    self.log.error(e)
 
         else:
-			self.log.info('using raw-video instead of endoded-previews for gui')
+            self.log.info('using raw-video instead of encoded-previews')
 
         # Setup Server-Connection, Demuxing and Decoding
         pipeline = """
@@ -55,7 +55,7 @@ class VideoDisplay(object):
         if use_previews:
             pipeline += """
                 demux. !
-				{vdec} !
+                {vdec} !
                 {previewcaps} !
                 queue !
             """
@@ -126,8 +126,8 @@ class VideoDisplay(object):
             vcaps=Config.get('mix', 'videocaps'),
             previewcaps=Config.get('previews', 'videocaps'),
             host=Args.host if Args.host else Config.get('server', 'host'),
-			vdec=vdec,
-			host=Config.get('server', 'host'),
+            vdec=vdec,
+            host=Config.get('server', 'host'),
             port=port,
         )
 

--- a/voctogui/lib/videodisplay.py
+++ b/voctogui/lib/videodisplay.py
@@ -16,16 +16,34 @@ class VideoDisplay(object):
         self.drawing_area = drawing_area
         self.level_callback = level_callback
 
-        caps = Config.get('mix', 'videocaps')
+		if Config.has_option('previews', 'videocaps'):
+			previewcaps = Config.get('previews', 'videocaps')
+		else:
+			previewcaps = Config.get('mix', 'videocaps')
+
         use_previews = (Config.getboolean('previews', 'enabled') and
                         Config.getboolean('previews', 'use'))
 
         # Preview-Ports are Raw-Ports + 1000
         if use_previews:
-            self.log.info('using jpeg-previews instead of raw-video for gui')
+			self.log.info('using endoded previews instead of raw-video for gui')
             port += 1000
+
+			vdec = 'image/jpeg ! jpegdec'
+			if Config.has_option('previews', 'vaapi'):
+				try:
+					decoder = Config.get('previews', 'vaapi')
+					decoders = {
+						'h264': 'video/x-h264 ! avdec_h264',
+						'jpeg': 'image/jpeg ! jpegdec',
+						'mpeg2': 'video/mpeg,mpegversion=2 ! mpeg2dec'
+					}
+					vdec = decoders[decoder]
+				except Exception as e:
+					self.log.error(e)
+
         else:
-            self.log.info('using raw-video instead of jpeg-previews for gui')
+			self.log.info('using raw-video instead of endoded-previews for gui')
 
         # Setup Server-Connection, Demuxing and Decoding
         pipeline = """
@@ -37,8 +55,7 @@ class VideoDisplay(object):
         if use_previews:
             pipeline += """
                 demux. !
-                image/jpeg !
-                jpegdec !
+				{vdec} !
                 {previewcaps} !
                 queue !
             """
@@ -109,6 +126,8 @@ class VideoDisplay(object):
             vcaps=Config.get('mix', 'videocaps'),
             previewcaps=Config.get('previews', 'videocaps'),
             host=Args.host if Args.host else Config.get('server', 'host'),
+			vdec=vdec,
+			host=Config.get('server', 'host'),
             port=port,
         )
 

--- a/voctogui/lib/videodisplay.py
+++ b/voctogui/lib/videodisplay.py
@@ -127,7 +127,6 @@ class VideoDisplay(object):
             previewcaps=Config.get('previews', 'videocaps'),
             host=Args.host if Args.host else Config.get('server', 'host'),
             vdec=vdec,
-            host=Config.get('server', 'host'),
             port=port,
         )
 


### PR DESCRIPTION
This PR enables a new Config-Option `vaapi` in the `[previews]` which switches the preview-encoders to vaapi-accelerated hardware. This offloads the CPU quite a bit and quality vs. bandwidth is not an issue here either.

he UI has a rudimentary understanding of the different encoders and which decoders need to be used for them, although only `none` and `h264` have been tested yet.