### PR TITLE
Audiosource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ target/
 
 #editor backups
 *~
+*.swp
 
 # this ain't an example anymore:
 example-scripts/config.sh

--- a/voctocore/default-config.ini
+++ b/voctocore/default-config.ini
@@ -5,6 +5,9 @@ audiocaps=audio/x-raw,format=S16LE,channels=2,layout=interleaved,rate=48000
 ; tcp-ports will be 10000,10001,10002
 sources=cam1,cam2,grabber
 
+; set the initial audio source
+audiosource=cam1
+
 
 [output-buffers]
 ; voctocore has a buffer on all video-outputs, that store video-frames for your

--- a/voctocore/lib/audiomix.py
+++ b/voctocore/lib/audiomix.py
@@ -8,10 +8,10 @@ from lib.clock import Clock
 
 class AudioMix(object):
 
-    def __init__(self):
+    def __init__(self, source=0):
         self.log = logging.getLogger('AudioMix')
 
-        self.selectedSource = 0
+        self.selectedSource = source
 
         self.caps = Config.get('mix', 'audiocaps')
         self.names = Config.getlist('mix', 'sources')

--- a/voctocore/lib/pipeline.py
+++ b/voctocore/lib/pipeline.py
@@ -60,8 +60,14 @@ class Pipeline(object):
         self.log.info('Creating Videmixer')
         self.vmix = VideoMix()
 
+        # check if there is an audio source preconfigured
+        try:
+            audiosource = names.index(Config.get('mix', 'audiosource'))
+        except:
+            audiosource = 0
+
         self.log.info('Creating Audiomixer')
-        self.amix = AudioMix()
+        self.amix = AudioMix(audiosource)
 
         port = 16000
         self.log.info('Creating Mixer-Background VSource at tcp-port %u', port)

--- a/voctocore/lib/videomix.py
+++ b/voctocore/lib/videomix.py
@@ -222,14 +222,14 @@ class VideoMix(object):
         try:
             apos = [int(i) for i in Config.get('side-by-side-preview',
                                                'apos').split('/', 1)]
-            self.log.debug('B-Video-Position configured to %u/%u',
+            self.log.debug('A-Video-Position configured to %u/%u',
                            apos[0], apos[1])
         except:
             apos = [
                 int(width / 100),  # 1%
                 int(width / 100)  # 1%
             ]
-            self.log.debug('B-Video-Position calculated to %u/%u',
+            self.log.debug('A-Video-Position calculated to %u/%u',
                            apos[0], apos[1])
 
         try:

--- a/voctogui/lib/ui.py
+++ b/voctogui/lib/ui.py
@@ -58,12 +58,16 @@ class Ui(UiBuilder):
             uibuilder=self
         )
 
-        drawing_area = self.find_widget_recursive(self.win, 'combo_audio')
-        self.audio_selector_controller = AudioSelectorController(
-            drawing_area,
-            win=self.win,
-            uibuilder=self
-        )
+        # check if there is a fixed audio source configured.
+        # if so, remove the combo-box entirely instead of setting it up.
+        if Config.has_option('mix', 'audiosource'):
+            drawing_area.remove(self.find_widget_recursive(self.win, 'box_audio'))
+        else:
+            self.audio_selector_controller = AudioSelectorController(
+                drawing_area=self.find_widget_recursive(self.win, 'combo_audio'),
+                win=self.win,
+                uibuilder=self
+            )
 
         # Setup Toolbar Controllers
         toolbar = self.find_widget_recursive(self.win, 'toolbar')

--- a/voctogui/lib/videodisplay.py
+++ b/voctogui/lib/videodisplay.py
@@ -44,6 +44,7 @@ class VideoDisplay(object):
 
         else:
             self.log.info('using raw-video instead of encoded-previews')
+            vdec = None
 
         # Setup Server-Connection, Demuxing and Decoding
         pipeline = """


### PR DESCRIPTION
This pull request is addressing issue #63, the configuration option to pre-select the audio source.

If such a config option is given, the corresponding GUI element in voctogui is removed.
This is done to prevent accidentally changing the audio source during production.

this branch contains the following commits:
197e6d8 added configuration option to specify initial audio source
b52dd80 fixed undefined variable when no previews are used
7ac47d6 fixed log message when reading "side-by-side-preview" config
6459e64 ignore vim temp files