### PR TITLE
Crop

### DIFF
--- a/voctocore/default-config.ini
+++ b/voctocore/default-config.ini
@@ -66,9 +66,12 @@ mix_out = 10000
 
 [side-by-side-preview]
 ;asize = 1024x576
+;acrop=0/0/0/0
 ;apos = 12/12
 ;bsize = 320x180
+;bcrop=0/640/0/640
 ;bpos = 948/528
+bpos=1620/506
 
 ; automatically select these sources when switching to sbs-preview
 ;default-a = grabber
@@ -76,6 +79,7 @@ mix_out = 10000
 
 [picture-in-picture]
 ;pipsize = 320x180
+;pipcrop=0/600/0/600
 ;pippos = 948/528
 
 ; automatically select these sources when switching to pip

--- a/voctocore/lib/videomix.py
+++ b/voctocore/lib/videomix.py
@@ -22,11 +22,19 @@ class PadState(object):
 
     def reset(self):
         self.alpha = 1.0
+
+        self.zorder = 1
+
         self.xpos = 0
         self.ypos = 0
-        self.zorder = 1
+
         self.width = 0
         self.height = 0
+
+        self.croptop = 0
+        self.cropleft = 0
+        self.cropbottom = 0
+        self.cropright = 0
 
 
 class VideoMix(object):
@@ -68,6 +76,7 @@ class VideoMix(object):
             pipeline += """
                 intervideosrc channel=video_{name}_mixer !
                 {caps} !
+                videocrop name=video_{idx}_cropper !
                 mix.
             """.format(
                 name=name,
@@ -221,6 +230,16 @@ class VideoMix(object):
                            asize[0], asize[1])
 
         try:
+            acrop = [int(i) for i in Config.get('side-by-side-preview',
+                                                'acrop').split('/', 3)]
+            self.log.debug('A-Video-Cropping configured to %u/%u/%u/%u',
+                           acrop[0], acrop[1], acrop[2], acrop[3])
+        except:
+            acrop = [0, 0, 0, 0]
+            self.log.debug('A-Video-Cropping calculated to %u/%u/%u/%u',
+                           acrop[0], acrop[1], acrop[2], acrop[3])
+
+        try:
             apos = [int(i) for i in Config.get('side-by-side-preview',
                                                'apos').split('/', 1)]
             self.log.debug('A-Video-Position configured to %u/%u',
@@ -247,6 +266,16 @@ class VideoMix(object):
                            bsize[0], bsize[1])
 
         try:
+            bcrop = [int(i) for i in Config.get('side-by-side-preview',
+                                                'bcrop').split('/', 3)]
+            self.log.debug('B-Video-Cropping configured to %u/%u/%u/%u',
+                           bcrop[0], bcrop[1], bcrop[2], bcrop[3])
+        except:
+            bcrop = [0, 0, 0, 0]
+            self.log.debug('B-Video-Cropping calculated to %u/%u/%u/%u',
+                           bcrop[0], bcrop[1], bcrop[2], bcrop[3])
+
+        try:
             bpos = [int(i) for i in Config.get('side-by-side-preview',
                                                'bpos').split('/', 1)]
             self.log.debug('B-Video-Position configured to %u/%u',
@@ -265,11 +294,19 @@ class VideoMix(object):
 
             if idx == self.sourceA:
                 pad.xpos, pad.ypos = apos
+                pad.croptop, \
+                    pad.cropleft, \
+                    pad.cropbottom, \
+                    pad.cropright = acrop
                 pad.width, pad.height = asize
                 pad.zorder = 1
 
             elif idx == self.sourceB:
                 pad.xpos, pad.ypos = bpos
+                pad.croptop, \
+                    pad.cropleft, \
+                    pad.cropbottom, \
+                    pad.cropright = bcrop
                 pad.width, pad.height = bsize
                 pad.zorder = 2
 
@@ -295,6 +332,16 @@ class VideoMix(object):
             ]
             self.log.debug('PIP-Size calculated to %ux%u',
                            pipsize[0], pipsize[1])
+
+        try:
+            pipcrop = [int(i) for i in Config.get('picture-in-picture',
+                                                  'pipcrop').split('/', 3)]
+            self.log.debug('PIP-Video-Cropping configured to %u/%u/%u/%u',
+                           pipcrop[0], pipcrop[1], pipcrop[2], pipcrop[3])
+        except:
+            pipcrop = [0, 0, 0, 0]
+            self.log.debug('PIP-Video-Cropping calculated to %u/%u/%u/%u',
+                           pipcrop[0], pipcrop[1], pipcrop[2], pipcrop[3])
 
         try:
             pippos = [int(i) for i in Config.get('picture-in-picture',
@@ -330,6 +377,8 @@ class VideoMix(object):
                             .get_by_name('mix')
                             .get_static_pad('sink_%u' % (idx + 1)))
 
+            cropper = self.mixingPipeline.get_by_name("video_%u_cropper" % idx)
+
             self.log.debug('Reconfiguring Mixerpad %u to '
                            'x/y=%u/%u, w/h=%u/%u alpha=%0.2f, zorder=%u',
                            idx, state.xpos, state.ypos,
@@ -341,6 +390,17 @@ class VideoMix(object):
             mixerpad.set_property('height', state.height)
             mixerpad.set_property('alpha', state.alpha)
             mixerpad.set_property('zorder', state.zorder)
+
+            self.log.info("Reconfiguring Cropper %d to %d/%d/%d/%d",
+                          idx,
+                          state.croptop,
+                          state.cropleft,
+                          state.cropbottom,
+                          state.cropright)
+            cropper.set_property("top", state.croptop)
+            cropper.set_property("left", state.cropleft)
+            cropper.set_property("bottom", state.cropbottom)
+            cropper.set_property("right", state.cropright)
 
     def selectCompositeModeDefaultSources(self):
         sectionNames = {

--- a/voctogui/ui/voctogui.ui
+++ b/voctogui/ui/voctogui.ui
@@ -185,6 +185,9 @@
                 <property name="homogeneous">True</property>
               </packing>
             </child>
+            <style>
+              <class name="primary-toolbar"/>
+            </style>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
This branch adds a cropping element to the pipeline that allows the removal of a superfluous part of the image.

To start out, configuration items for the picture-in-picture and the side-by-side-preview mode were added. For the latter this allows the final mix to be set up for example like illustrated in the following schematic:
![screen](https://cloud.githubusercontent.com/assets/649091/20237902/4d90b344-a8df-11e6-947e-ce40b45f9b8a.png)

The reasoning behind this is, that source B usually shows the speaker who only occupies the middle part of the frame.

From a technical perspective, the cropping of each side of a source is determined by the corresponding newly introduced attribute of the PadState object (croptop, cropleft, cropbottom, cropright). These attributes are set just like xpos, ypos, width and height when choosing a new Mixer state.

If the configuration items are not present in the config file, the four attributes fall back to 0 and no cropping is done. (i.e. the system is backwards compatible and all preexisting config files can still be used)

In a next, still to be implemented, step, this cropping can also be used to remove the black bars from a padded source (4:3 screen grabbing with black bars to fit 16:9 video stream)