### PR TITLE
fix for #117 (voctomix leaking file descriptors)

### DIFF
--- a/voctocore/lib/tcpmulticonnection.py
+++ b/voctocore/lib/tcpmulticonnection.py
@@ -43,6 +43,7 @@ class TCPMultiConnection(object):
 
     def close_connection(self, conn):
         if conn in self.currentConnections:
+            conn.close()
             del(self.currentConnections[conn])
         self.log.info('Now %u Receiver connected',
                       len(self.currentConnections))

--- a/voctocore/lib/tcpsingleconnection.py
+++ b/voctocore/lib/tcpsingleconnection.py
@@ -41,5 +41,6 @@ class TCPSingleConnection(object):
         return True
 
     def close_connection(self):
+        self.currentConnection.close()
         self.currentConnection = None
         self.log.info('Connection closed')


### PR DESCRIPTION
On connection close voctocore doesn't close the sockets, leading
to a leak.