### PR TITLE
allow audio and video only streams

### DIFF
--- a/voctocore/lib/audiomix.py
+++ b/voctocore/lib/audiomix.py
@@ -13,7 +13,16 @@ class AudioMix(object):
         self.log = logging.getLogger('AudioMix')
 
         self.caps = Config.get('mix', 'audiocaps')
-        self.names = Config.getlist('mix', 'sources')
+
+        try:
+            video_only = Config.getlist('mix', 'video_only')
+        except Exception:
+            video_only = []
+
+        self.names = [name for name in
+                      Config.getlist('mix', 'sources')
+                      if name not in video_only]
+
         self.log.info('Configuring Mixer for %u Sources', len(self.names))
 
         # initialize all sources to silent

--- a/voctocore/lib/commands.py
+++ b/voctocore/lib/commands.py
@@ -15,6 +15,8 @@ class ControlServerCommands(object):
         self.pipeline = pipeline
 
         self.sources = Config.getlist('mix', 'sources')
+        self.audio_sources = []
+        self.video_sources = []
         if Config.getboolean('stream-blanker', 'enabled'):
             self.blankerSources = Config.getlist('stream-blanker', 'sources')
 
@@ -57,9 +59,34 @@ class ControlServerCommands(object):
         helplines.append('\t' + 'quit / exit')
 
         helplines.append("\n")
-        helplines.append("Source-Names:")
+
+        video_only = []
+        audio_only = []
+
+        try:
+            audio_only = Config.getlist('mix', 'audio_only')
+            video_only = Config.getlist('mix', 'video_only')
+        except Exception:
+            pass
+
+        helplines.append("Mixed-Source Names:")
         for source in self.sources:
-            helplines.append("\t" + source)
+            if source not in audio_only and source not in video_only:
+                helplines.append("\t" + source)
+                self.audio_sources.append(source)
+                self.video_sources.append(source)
+
+        helplines.append("Video-Source Names:")
+        for source in self.sources:
+            if source in video_only:
+                helplines.append("\t" + source)
+                self.video_sources.append(source)
+
+        helplines.append("Audio-Source Names:")
+        for source in self.sources:
+            if source in audio_only:
+                helplines.append("\t" + source)
+                self.audio_sources.append(source)
 
         if Config.getboolean('stream-blanker', 'enabled'):
             helplines.append("\n")
@@ -75,8 +102,8 @@ class ControlServerCommands(object):
         return OkResponse("\n".join(helplines))
 
     def _get_video_status(self):
-        a = self.sources[self.pipeline.vmix.getVideoSourceA()]
-        b = self.sources[self.pipeline.vmix.getVideoSourceB()]
+        a = self.video_sources[self.pipeline.vmix.getVideoSourceA()]
+        b = self.video_sources[self.pipeline.vmix.getVideoSourceB()]
         return [a, b]
 
     def get_video(self):
@@ -89,7 +116,7 @@ class ControlServerCommands(object):
         """sets the video-source A to the supplied source-name or source-id,
            swapping A and B if the supplied source is currently used as
            video-source B"""
-        src_id = self.sources.index(src_name)
+        src_id = self.video_sources.index(src_name)
         self.pipeline.vmix.setVideoSourceA(src_id)
 
         status = self._get_video_status()
@@ -99,7 +126,7 @@ class ControlServerCommands(object):
         """sets the video-source B to the supplied source-name or source-id,
            swapping A and B if the supplied source is currently used as
            video-source A"""
-        src_id = self.sources.index(src_name)
+        src_id = self.video_sources.index(src_name)
         self.pipeline.vmix.setVideoSourceB(src_id)
 
         status = self._get_video_status()
@@ -109,7 +136,7 @@ class ControlServerCommands(object):
         volumes = self.pipeline.amix.getAudioVolumes()
 
         return json.dumps({
-            self.sources[idx]: round(volume, 4)
+            self.audio_sources[idx]: round(volume, 4)
             for idx, volume in enumerate(volumes)
         })
 
@@ -120,7 +147,7 @@ class ControlServerCommands(object):
 
     def set_audio(self, src_name):
         """sets the audio-source to the supplied source-name or source-id"""
-        src_id = self.sources.index(src_name)
+        src_id = self.audio_sources.index(src_name)
         self.pipeline.amix.setAudioSource(src_id)
 
         status = self._get_audio_status()
@@ -128,7 +155,7 @@ class ControlServerCommands(object):
 
     def set_audio_volume(self, src_name, volume):
         """sets the volume of the supplied source-name or source-id"""
-        src_id = self.sources.index(src_name)
+        src_id = self.audio_sources.index(src_name)
         volume = float(volume)
         if volume < 0.0:
             raise ValueError("volume must be positive")
@@ -163,11 +190,11 @@ class ControlServerCommands(object):
         """sets the A- and the B-source synchronously with the composition-mode
            all parametets can be set to "*" which will leave them unchanged."""
         if src_a_name != '*':
-            src_a_id = self.sources.index(src_a_name)
+            src_a_id = self.video_sources.index(src_a_name)
             self.pipeline.vmix.setVideoSourceA(src_a_id)
 
         if src_b_name != '*':
-            src_b_id = self.sources.index(src_b_name)
+            src_b_id = self.video_sources.index(src_b_name)
             self.pipeline.vmix.setVideoSourceB(src_b_id)
 
         if mode_name != '*':

--- a/voctocore/lib/commands.py
+++ b/voctocore/lib/commands.py
@@ -100,12 +100,8 @@ class ControlServerCommands(object):
         return OkResponse("\n".join(helplines))
 
     def _get_video_status(self):
-        try:
-            a = self.video_sources[self.pipeline.vmix.getVideoSourceA()]
-            b = self.video_sources[self.pipeline.vmix.getVideoSourceB()]
-        except Exception as e:
-            print("\nException!", self.video_sources)
-            raise e
+        a = self.video_sources[self.pipeline.vmix.getVideoSourceA()]
+        b = self.video_sources[self.pipeline.vmix.getVideoSourceB()]
         return [a, b]
 
     def get_video(self):

--- a/voctocore/lib/commands.py
+++ b/voctocore/lib/commands.py
@@ -17,6 +17,25 @@ class ControlServerCommands(object):
         self.sources = Config.getlist('mix', 'sources')
         self.audio_sources = []
         self.video_sources = []
+
+        video_only = []
+        audio_only = []
+
+        try:
+            audio_only = Config.getlist('mix', 'audio_only')
+            video_only = Config.getlist('mix', 'video_only')
+        except Exception:
+            pass
+
+        for source in self.sources:
+            if source not in audio_only and source not in video_only:
+                self.audio_sources.append(source)
+                self.video_sources.append(source)
+            elif source in video_only:
+                self.video_sources.append(source)
+            elif source in audio_only:
+                self.audio_sources.append(source)
+
         if Config.getboolean('stream-blanker', 'enabled'):
             self.blankerSources = Config.getlist('stream-blanker', 'sources')
 
@@ -59,34 +78,13 @@ class ControlServerCommands(object):
         helplines.append('\t' + 'quit / exit')
 
         helplines.append("\n")
-
-        video_only = []
-        audio_only = []
-
-        try:
-            audio_only = Config.getlist('mix', 'audio_only')
-            video_only = Config.getlist('mix', 'video_only')
-        except Exception:
-            pass
-
-        helplines.append("Mixed-Source Names:")
-        for source in self.sources:
-            if source not in audio_only and source not in video_only:
-                helplines.append("\t" + source)
-                self.audio_sources.append(source)
-                self.video_sources.append(source)
-
         helplines.append("Video-Source Names:")
-        for source in self.sources:
-            if source in video_only:
-                helplines.append("\t" + source)
-                self.video_sources.append(source)
+        for source in self.video_sources:
+            helplines.append("\t" + source)
 
         helplines.append("Audio-Source Names:")
         for source in self.sources:
-            if source in audio_only:
-                helplines.append("\t" + source)
-                self.audio_sources.append(source)
+            helplines.append("\t" + source)
 
         if Config.getboolean('stream-blanker', 'enabled'):
             helplines.append("\n")
@@ -102,8 +100,12 @@ class ControlServerCommands(object):
         return OkResponse("\n".join(helplines))
 
     def _get_video_status(self):
-        a = self.video_sources[self.pipeline.vmix.getVideoSourceA()]
-        b = self.video_sources[self.pipeline.vmix.getVideoSourceB()]
+        try:
+            a = self.video_sources[self.pipeline.vmix.getVideoSourceA()]
+            b = self.video_sources[self.pipeline.vmix.getVideoSourceB()]
+        except Exception as e:
+            print("\nException!", self.video_sources)
+            raise e
         return [a, b]
 
     def get_video(self):

--- a/voctocore/lib/pipeline.py
+++ b/voctocore/lib/pipeline.py
@@ -29,6 +29,14 @@ class Pipeline(object):
         self.previews = []
         self.sbsources = []
 
+        audio_only = []
+        video_only = []
+        try:
+            audio_only = Config.getlist('mix', 'audio_only')
+            video_only = Config.getlist('mix', 'video_only')
+        except Exception:
+            pass
+
         self.log.info('Creating %u AVSources: %s', len(names), names)
         for idx, name in enumerate(names):
             port = 10000 + idx
@@ -39,7 +47,10 @@ class Pipeline(object):
             if Config.getboolean('mirrors', 'enabled'):
                 outputs.append(name + '_mirror')
 
-            source = spawn_source(name, port, outputs=outputs)
+            has_audio = name not in video_only
+            has_video = name not in audio_only
+            source = spawn_source(name, port, outputs=outputs,
+                                  has_audio=has_audio, has_video=has_video)
             self.log.info('Creating AVSource %s as %s', name, source)
             self.sources.append(source)
 

--- a/voctocore/lib/videomix.py
+++ b/voctocore/lib/videomix.py
@@ -35,8 +35,15 @@ class VideoMix(object):
     def __init__(self):
         self.caps = Config.get('mix', 'videocaps')
 
-        self.names = Config.getlist('mix', 'sources')
-        self.log.info('Configuring Mixer for %u Sources', len(self.names))
+        try:
+            audio_only = Config.getlist('mix', 'audio_only')
+        except Exception:
+            audio_only = []
+
+        self.names = [name for name in
+                      Config.getlist('mix', 'sources')
+                      if name not in audio_only]
+        self.log.info('Configuring VideoMixer for %u Sources', len(self.names))
 
         pipeline = """
             compositor name=mix !

--- a/voctocore/tests/test_exclusive_sources.py
+++ b/voctocore/tests/test_exclusive_sources.py
@@ -1,0 +1,26 @@
+import unittest
+
+from lib.errors.configuration_error import ConfigurationError
+from tests.helper.voctomix_test import VoctomixTest
+from lib.audiomix import AudioMix
+from lib.videomix import VideoMix
+from lib.config import Config
+
+
+# noinspection PyUnusedLocal
+class ExclusiveSources(VoctomixTest):
+
+    def test_exclusive_sources(self):
+        Config.given("mix", "audio_only", "cam2")
+        Config.given("mix", "video_only", "grabber")
+        audiomixer = AudioMix()
+        videomixer = VideoMix()
+
+        self.assertListEqual(audiomixer.names, ["cam1", "cam2"])
+        self.assertListEqual(audiomixer.volumes, [1.0, 0.0])
+
+        self.assertListEqual(videomixer.names, ["cam1", "grabber"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/voctocore/tests/test_exclusive_sources.py
+++ b/voctocore/tests/test_exclusive_sources.py
@@ -10,7 +10,7 @@ from lib.config import Config
 # noinspection PyUnusedLocal
 class ExclusiveSources(VoctomixTest):
 
-    def test_exclusive_sources(self):
+    def test_exclusive_sources_not_in_both_types(self):
         Config.given("mix", "audio_only", "cam2")
         Config.given("mix", "video_only", "grabber")
         audiomixer = AudioMix()
@@ -20,6 +20,30 @@ class ExclusiveSources(VoctomixTest):
         self.assertListEqual(audiomixer.volumes, [1.0, 0.0])
 
         self.assertListEqual(videomixer.names, ["cam1", "grabber"])
+
+    def test_exclusive_sources_dont_accept_invalid_type(self):
+        Config.given("mix", "audio_only", "cam2")
+        Config.given("mix", "video_only", "grabber")
+        audiomixer = AudioMix()
+        videomixer = VideoMix()
+
+        src_id = audiomixer.names.index("cam1")
+        audiomixer.setAudioSource(src_id)
+        # should succeed
+
+        with self.assertRaises(ValueError):
+            src_id = audiomixer.names.index("grabber")
+            audiomixer.setAudioSource(src_id)
+        # should fail
+
+        src_id = videomixer.names.index("cam1")
+        audiomixer.setAudioSource(src_id)
+        # should succeed
+
+        with self.assertRaises(ValueError):
+            src_id = videomixer.names.index("cam2")
+            audiomixer.setAudioSource(src_id)
+        # should fail
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This addresses part of my performance related "bug" (#127).
It seems that removing the unnecessary streams + the unnecessary generation of videotestsrc and audiotestsrc that were fed to comply with the required caps helps a lot.


I added two options to the config `audio_only` and `video_only`, which are lists representing which sources do not have audio/video. These are optional and if not present the behavior stays the same as it was until now.

When trying to set an audio_only source as video, nothing happens, it will just render the background image if present (black if there's no background feed)

When trying to set a video_only source as audio, there's no audio at all.

PS: My personal config and motivation to do this:

```ini
sources=slides,cam1,cam2,audio1,audio2,video
audio_only=audio1,audio2
video_only=slides,cam1,cam2
```
I only get a mixed stream from `video`