### PR TITLE
Add option to disable mirror outputs

### DIFF
--- a/voctocore/default-config.ini
+++ b/voctocore/default-config.ini
@@ -76,3 +76,8 @@ deinterlace=false
 [stream-blanker]
 enabled=true
 sources=pause,nostream
+
+[mirrors]
+; disable if not needed
+enabled=true
+

--- a/voctocore/lib/pipeline.py
+++ b/voctocore/lib/pipeline.py
@@ -35,19 +35,22 @@ class Pipeline(object):
             port = 10000 + idx
             self.log.info('Creating AVSource %s at tcp-port %u', name, port)
 
-            outputs = [name + '_mixer', name + '_mirror']
+            outputs = [name + '_mixer']
             if Config.getboolean('previews', 'enabled'):
                 outputs.append(name + '_preview')
+            if Config.getboolean('mirrors', 'enabled'):
+                outputs.append(name + '_mirror')
 
             source = AVSource(name, port, outputs=outputs)
             self.sources.append(source)
 
-            port = 13000 + idx
-            self.log.info('Creating Mirror-Output for AVSource %s '
-                          'at tcp-port %u', name, port)
+            if Config.getboolean('mirrors', 'enabled'):
+                port = 13000 + idx
+                self.log.info('Creating Mirror-Output for AVSource %s '
+                              'at tcp-port %u', name, port)
 
-            mirror = AVRawOutput('%s_mirror' % name, port)
-            self.mirrors.append(mirror)
+                mirror = AVRawOutput('%s_mirror' % name, port)
+                self.mirrors.append(mirror)
 
             if Config.getboolean('previews', 'enabled'):
                 port = 14000 + idx


### PR DESCRIPTION
This PR adds an option to disable mirror ports, by default the behavior is the same as before (although you need the "mirrors" section in the config file)