### PR TITLE
enable multiple audio sources to play at the same time with independent volume

### DIFF
--- a/voctocore/default-config.ini
+++ b/voctocore/default-config.ini
@@ -6,7 +6,7 @@ audiocaps=audio/x-raw,format=S16LE,channels=2,layout=interleaved,rate=48000
 sources=cam1,cam2,grabber
 
 ; set the initial audio source
-audiosource=cam1
+audiosource=cam1,cam2
 
 
 [output-buffers]

--- a/voctocore/lib/audiomix.py
+++ b/voctocore/lib/audiomix.py
@@ -65,8 +65,9 @@ class AudioMix(object):
         self.mixingPipeline.set_state(Gst.State.PLAYING)
 
 
-    def updateSourceVolume(self, idx, volume):
+    def updateSourceVolume(self, name, volume):
         volume = max(0, min(1, float(volume)))  # Clamp volume between 0 and 1
+        idx = self.names.index(name)
         self.log.debug('Setting Mixerpad %u to volume=%0.2f', idx, volume)
         mixerpad = (self.mixingPipeline.get_by_name('mix')
                                        .get_static_pad('sink_%u' % idx))

--- a/voctocore/lib/audiomix.py
+++ b/voctocore/lib/audiomix.py
@@ -95,7 +95,9 @@ class AudioMix(object):
 
     def getSourceVolume(self):
         out = {}
-        for idx in range(0, len(self.names) - 1):
+        print(self.names)
+        for idx in range(0, len(self.names)):
+            print(idx)
             mixerpad = (self.mixingPipeline.get_by_name('mix')
                                            .get_static_pad('sink_%u' % idx))
             volume = mixerpad.get_property('volume')

--- a/voctocore/lib/audiomix.py
+++ b/voctocore/lib/audiomix.py
@@ -64,6 +64,15 @@ class AudioMix(object):
         self.log.debug('Launching Mixing-Pipeline')
         self.mixingPipeline.set_state(Gst.State.PLAYING)
 
+
+    def updateSourceVolume(self, idx, volume):
+        volume = max(0, min(1, float(volume)))  # Clamp volume between 0 and 1
+        self.log.debug('Setting Mixerpad %u to volume=%0.2f', idx, volume)
+        mixerpad = (self.mixingPipeline.get_by_name('mix')
+                                       .get_static_pad('sink_%u' % idx))
+        mixerpad.set_property('volume', volume)
+
+
     def updateMixerState(self):
         self.log.info('Updating Mixer-State')
 
@@ -81,6 +90,16 @@ class AudioMix(object):
 
     def getAudioSource(self):
         return self.selectedSource
+
+    def getSourceVolume(self):
+        out = {}
+        for idx in range(0, len(self.names) - 1):
+            mixerpad = (self.mixingPipeline.get_by_name('mix')
+                                           .get_static_pad('sink_%u' % idx))
+            volume = mixerpad.get_property('volume')
+            name = self.names[idx]
+            out[name] = volume
+        return out
 
     def on_eos(self, bus, message):
         self.log.debug('Received End-of-Stream-Signal on Mixing-Pipeline')

--- a/voctocore/lib/audiomix.py
+++ b/voctocore/lib/audiomix.py
@@ -95,9 +95,7 @@ class AudioMix(object):
 
     def getSourceVolume(self):
         out = {}
-        print(self.names)
         for idx in range(0, len(self.names)):
-            print(idx)
             mixerpad = (self.mixingPipeline.get_by_name('mix')
                                            .get_static_pad('sink_%u' % idx))
             volume = mixerpad.get_property('volume')

--- a/voctocore/lib/audiomix.py
+++ b/voctocore/lib/audiomix.py
@@ -85,7 +85,8 @@ class AudioMix(object):
                                            .get_static_pad('sink_%u' % idx))
             mixerpad.set_property('volume', volume)
 
-    def setAudioSource(self, source):
+    def setAudioSource(self, name):
+        source = self.names.index(name)
         self.selectedSource = source
         self.updateMixerState()
 

--- a/voctocore/lib/commands.py
+++ b/voctocore/lib/commands.py
@@ -154,6 +154,10 @@ class ControlServerCommands(object):
         src_id = self.pipeline.amix.getAudioSource()
         return encodeName(self.sources, src_id)
 
+    def _get_source_volume(self):
+        vol = self.pipeline.amix.getSourceVolume()
+        return str(vol)
+
     def get_audio(self):
         """gets the name of the current audio-source"""
         status = self._get_audio_status()
@@ -166,6 +170,20 @@ class ControlServerCommands(object):
 
         status = self._get_audio_status()
         return NotifyResponse('audio_status', status)
+
+    def get_audio_volume(self):
+        """gets the names and volumes of all audio-sources"""
+        status = self._get_source_volume()
+        return OkResponse('audio_volume', status)
+
+    def set_audio_volume(self, src_name_or_id, volume):
+        """sets the audio-source volume to the
+           supplied source-name or source-id and level"""
+        src_id = decodeName(self.sources, src_name_or_id)
+        self.pipeline.amix.updateSourceVolume(src_id, volume)
+
+        vol = self._get_source_volume()
+        return NotifyResponse('source_volume', vol)
 
     def _get_composite_status(self):
         mode = self.pipeline.vmix.getCompositeMode()

--- a/voctocore/lib/commands.py
+++ b/voctocore/lib/commands.py
@@ -166,7 +166,7 @@ class ControlServerCommands(object):
     def set_audio(self, src_name_or_id):
         """sets the audio-source to the supplied source-name or source-id"""
         src_id = decodeName(self.sources, src_name_or_id)
-        self.pipeline.amix.setAudioSource(self.names[src_id])
+        self.pipeline.amix.setAudioSource(self.sources[src_id])
 
         status = self._get_audio_status()
         return NotifyResponse('audio_status', status)

--- a/voctocore/lib/commands.py
+++ b/voctocore/lib/commands.py
@@ -180,7 +180,7 @@ class ControlServerCommands(object):
         """sets the audio-source volume to the
            supplied source-name or source-id and level"""
         src_id = decodeName(self.sources, src_name_or_id)
-        self.pipeline.amix.updateSourceVolume(src_id, volume)
+        self.pipeline.amix.updateSourceVolume(self.sources[src_id], volume)
 
         vol = self._get_source_volume()
         return NotifyResponse('source_volume', vol)

--- a/voctocore/lib/commands.py
+++ b/voctocore/lib/commands.py
@@ -166,7 +166,7 @@ class ControlServerCommands(object):
     def set_audio(self, src_name_or_id):
         """sets the audio-source to the supplied source-name or source-id"""
         src_id = decodeName(self.sources, src_name_or_id)
-        self.pipeline.amix.setAudioSource(src_id)
+        self.pipeline.amix.setAudioSource(self.names[src_id])
 
         status = self._get_audio_status()
         return NotifyResponse('audio_status', status)


### PR DESCRIPTION
This PR enables having multiple audio sources play back at the same time, each has its own controllable level.

executing audio_source <source> will keep its old behavir and set all other sources back to 0.