### PR TITLE
Crop (second attempt)

### DIFF
--- a/voctocore/default-config.ini
+++ b/voctocore/default-config.ini
@@ -75,8 +75,10 @@ mix_out = 10000
 
 [side-by-side-preview]
 ;asize = 1024x576
+;acrop=0/0/0/0
 ;apos = 12/12
 ;bsize = 320x180
+;bcrop=0/640/0/640
 ;bpos = 948/528
 
 ; automatically select these sources when switching to sbs-preview
@@ -85,6 +87,7 @@ mix_out = 10000
 
 [picture-in-picture]
 ;pipsize = 320x180
+;pipcrop=0/600/0/600
 ;pippos = 948/528
 
 ; automatically select these sources when switching to pip

--- a/voctogui/ui/voctogui.ui
+++ b/voctogui/ui/voctogui.ui
@@ -185,6 +185,9 @@
                 <property name="homogeneous">True</property>
               </packing>
             </child>
+            <style>
+              <class name="primary-toolbar"/>
+            </style>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
(Second attempt, first merge request can't be reopened…)

This branch adds a cropping element to the pipeline that allows the removal of a superfluous part of the image.

To do this, configuration items for the picture-in-picture and the side-by-side-preview mode were added. For the latter this allows the final mix to be set up for example like illustrated in the following schematic:
![screen](https://cloud.githubusercontent.com/assets/649091/20237902/4d90b344-a8df-11e6-947e-ce40b45f9b8a.png)

The reasoning behind this is, that source B usually shows the speaker who only occupies the middle part of the frame.

From a technical perspective, the cropping of each side of a source is determined by the corresponding newly introduced attribute of the PadState object (croptop, cropleft, cropbottom, cropright). These attributes are set just like xpos, ypos, width and height when choosing a new Mixer state.

If the configuration items are not present in the config file, the four attributes fall back to 0 and no cropping is done. (i.e. the system is backwards compatible and all preexisting config files can still be used)

In a next, still to be implemented, step, this cropping can also be used to remove the black bars from a padded source (4:3 screen grabbing with black bars to fit 16:9 video stream)