### PR TITLE
Add a docker-compose file for quickstart testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ Now proceed as described under [Installation](#installation).
 
 ## Quickstart using Docker
 
+### docker-compose
+
+Run the core, gui and two example source streams
+```
+xhost +local:$(id -un)
+mkdir /tmp/vocto/ && touch /tmp/vocto/configgui.ini
+GID=$(id -g) UID=$(id -u) docker-compose up
+```
+
+Run only the core
+```
+docker-compose up voctocore
+```
+
+Clean up stale containers
+```
+docker-compose rm
+```
+
+### Manually
+
 Run the core and two example source streams
 ```
 docker run -it --rm --name=voctocore c3voc/voctomix core

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Now proceed as described under [Installation](#installation).
 
 ### docker-compose
 
+Install docker-compose (prerequisite)
+```
+apt install docker-compose      # debian
+dnf install docker-compose      # fedora
+```
+
 Run the core, gui and two example source streams
 ```
 xhost +local:$(id -un)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+---
+version: '3.4'
+
+services:
+  voctocore:
+    image: c3voc/voctomix
+    command: core
+    container_name: voctocore
+    networks:
+      voctomix:
+        aliases:
+          - corehost
+  source_cam1:
+    image: c3voc/voctomix
+    command: gstreamer/source-videotestsrc-as-cam1.sh
+    container_name: source_cam1
+    depends_on:
+      - voctocore
+    networks:
+      - voctomix
+  source_bg:
+    image: c3voc/voctomix
+    command: gstreamer/source-videotestsrc-as-background-loop.sh
+    container_name: source_bg
+    depends_on:
+      - voctocore
+    networks:
+      - voctomix
+  voctogui:
+    image: c3voc/voctomix
+    command: gui
+    container_name: voctogui
+    depends_on:
+      - voctocore
+    environment:
+      DISPLAY: :0
+      uid: ${UID}
+      gid: ${GID}
+    volumes:
+      - type: bind
+        source: /tmp/vocto/configgui.ini
+        target: /opt/voctomix/voctogui/config.ini
+      - type: bind
+        source: /tmp/.X11-unix
+        target: /tmp/.X11-unix
+      - type: bind
+        source: /tmp/.docker.xauth
+        target: /tmp/.docker.xauth
+    networks:
+      - voctomix
+
+networks:
+  voctomix:
+...


### PR DESCRIPTION
This PR adds a `docker-compose` file in order to simplify quickstart testing.