### PR TITLE
improve audio level display

### DIFF
--- a/voctogui/lib/audioleveldisplay.py
+++ b/voctogui/lib/audioleveldisplay.py
@@ -130,7 +130,8 @@ class AudioLevelDisplay(object):
         return max(min(value, max_value), min_value)
 
     def level_callback(self, rms, peak, decay):
-        self.levelrms = rms
-        self.levelpeak = peak
-        self.leveldecay = decay
-        self.drawing_area.queue_draw()
+        if self.levelrms != rms or self.levelpeak != peak or self.leveldecay != decay:
+            self.levelrms = rms
+            self.levelpeak = peak
+            self.leveldecay = decay
+            self.drawing_area.queue_draw()

--- a/voctogui/lib/audioleveldisplay.py
+++ b/voctogui/lib/audioleveldisplay.py
@@ -17,6 +17,8 @@ class AudioLevelDisplay(object):
         self.levelpeak = []
         self.leveldecay = []
 
+        self.height = -1
+
         # register on_draw handler
         self.drawing_area.connect('draw', self.on_draw)
 
@@ -60,11 +62,13 @@ class AudioLevelDisplay(object):
         peak_px = [self.normalize_db(db) * height for db in self.levelpeak]
         decay_px = [self.normalize_db(db) * height for db in self.leveldecay]
 
-        # setup gradients for all level bars
-        bg_lg = self.gradient(0.25, 0.0, height)
-        rms_lg = self.gradient(1.0, 0.0, height)
-        peak_lg = self.gradient(0.75, 0.0, height)
-        decay_lg = self.gradient(1.0, 0.5, height)
+        if self.height != height:
+            self.height = height
+            # setup gradients for all level bars
+            self.bg_lg = self.gradient(0.25, 0.0, height)
+            self.rms_lg = self.gradient(1.0, 0.0, height)
+            self.peak_lg = self.gradient(0.75, 0.0, height)
+            self.decay_lg = self.gradient(1.0, 0.5, height)
 
         # draw all level bars for all channels
         for channel in range(0, channels):
@@ -73,25 +77,25 @@ class AudioLevelDisplay(object):
 
             # draw background
             cr.rectangle(x, 0, channel_width, height - peak_px[channel])
-            cr.set_source(bg_lg)
+            cr.set_source(self.bg_lg)
             cr.fill()
 
             # draw peak bar
             cr.rectangle(
                 x, height - peak_px[channel], channel_width, peak_px[channel])
-            cr.set_source(peak_lg)
+            cr.set_source(self.peak_lg)
             cr.fill()
 
             # draw rms bar below
             cr.rectangle(
                 x, height - rms_px[channel], channel_width,
                 rms_px[channel] - peak_px[channel])
-            cr.set_source(rms_lg)
+            cr.set_source(self.rms_lg)
             cr.fill()
 
             # draw decay bar
             cr.rectangle(x, height - decay_px[channel], channel_width, 2)
-            cr.set_source(decay_lg)
+            cr.set_source(self.decay_lg)
             cr.fill()
 
             # draw medium grey margin bar

--- a/voctogui/lib/audioleveldisplay.py
+++ b/voctogui/lib/audioleveldisplay.py
@@ -102,11 +102,11 @@ class AudioLevelDisplay(object):
              xadvance, yadvance) = cr.text_extents(text)
 
             y = self.normalize_db(db) * height
-            if y > peak_px[channel]:
+            if y > peak_px[channels - 1]:
                 cr.set_source_rgb(1, 1, 1)
             else:
                 cr.set_source_rgb(0, 0, 0)
-            cr.move_to((width - textwidth) / 2, height - y - textheight)
+            cr.move_to((width - textwidth) - 2, height - y - textheight)
             cr.show_text(text)
 
         return True

--- a/voctogui/lib/audioleveldisplay.py
+++ b/voctogui/lib/audioleveldisplay.py
@@ -2,6 +2,7 @@ import logging
 import math
 import cairo
 
+
 class AudioLevelDisplay(object):
     """Displays a Level-Meter of another VideoDisplay into a GtkWidget"""
 
@@ -69,9 +70,11 @@ class AudioLevelDisplay(object):
         peak_lg.add_color_stop_rgb(1.0, 0, peak_fade, 0)
 
         decay_lg = cairo.LinearGradient(0, 0, 0, height)
-        decay_lg.add_color_stop_rgb(0.0, 1, decay_invers_fade, decay_invers_fade)
+        decay_lg.add_color_stop_rgb(
+            0.0, 1, decay_invers_fade, decay_invers_fade)
         decay_lg.add_color_stop_rgb(0.5, 1, 1, decay_invers_fade)
-        decay_lg.add_color_stop_rgb(1.0, decay_invers_fade, 1, decay_invers_fade)
+        decay_lg.add_color_stop_rgb(
+            1.0, decay_invers_fade, 1, decay_invers_fade)
 
         # draw all level bars for all channels
         for channel in range(0, channels):
@@ -84,12 +87,15 @@ class AudioLevelDisplay(object):
             cr.fill()
 
             # draw peak bar
-            cr.rectangle(x, height - peak_px[channel], channel_width, peak_px[channel])
+            cr.rectangle(
+                x, height - peak_px[channel], channel_width, peak_px[channel])
             cr.set_source(peak_lg)
             cr.fill()
 
             # draw rms bar below
-            cr.rectangle(x, height - rms_px[channel], channel_width, rms_px[channel] - peak_px[channel])
+            cr.rectangle(
+                x, height - rms_px[channel], channel_width,
+                rms_px[channel] - peak_px[channel])
             cr.set_source(rms_lg)
             cr.fill()
 

--- a/voctogui/lib/audioleveldisplay.py
+++ b/voctogui/lib/audioleveldisplay.py
@@ -134,8 +134,8 @@ class AudioLevelDisplay(object):
         return max(min(value, max_value), min_value)
 
     def level_callback(self, rms, peak, decay):
-        if (self.levelrms != rms or self.levelpeak != peak or
-                self.leveldecay != decay):
+        if self.levelrms != rms or self.levelpeak != peak \
+                or self.leveldecay != decay:
             self.levelrms = rms
             self.levelpeak = peak
             self.leveldecay = decay

--- a/voctogui/lib/audioleveldisplay.py
+++ b/voctogui/lib/audioleveldisplay.py
@@ -95,7 +95,6 @@ class AudioLevelDisplay(object):
             cr.fill()
 
         # draw db text-markers
-        cr.set_source_rgb(1, 1, 1)
         for db in [-40, -20, -10, -5, -4, -3, -2, -1]:
             text = str(db)
             (xbearing, ybearing,
@@ -103,6 +102,10 @@ class AudioLevelDisplay(object):
              xadvance, yadvance) = cr.text_extents(text)
 
             y = self.normalize_db(db) * height
+            if y > peak_px[channel]:
+                cr.set_source_rgb(1, 1, 1)
+            else:
+                cr.set_source_rgb(0, 0, 0)
             cr.move_to((width - textwidth) / 2, height - y - textheight)
             cr.show_text(text)
 

--- a/voctogui/lib/audioleveldisplay.py
+++ b/voctogui/lib/audioleveldisplay.py
@@ -64,7 +64,7 @@ class AudioLevelDisplay(object):
         bg_lg = self.gradient(0.25, 0.0, height)
         rms_lg = self.gradient(1.0, 0.0, height)
         peak_lg = self.gradient(0.75, 0.0, height)
-        decay_lg = self.gradient(0.0, 0.5, height)
+        decay_lg = self.gradient(1.0, 0.5, height)
 
         # draw all level bars for all channels
         for channel in range(0, channels):

--- a/voctogui/lib/audioleveldisplay.py
+++ b/voctogui/lib/audioleveldisplay.py
@@ -20,6 +20,19 @@ class AudioLevelDisplay(object):
         # register on_draw handler
         self.drawing_area.connect('draw', self.on_draw)
 
+    # generate gradient from green to yellow to red in logarithmic scale
+    def gradient(self, brightness, darkness, height):
+        # prepare gradient
+        lg = cairo.LinearGradient(0, 0, 0, height)
+        # set gradient stops
+        lg.add_color_stop_rgb(0.0, brightness, darkness, darkness)
+        lg.add_color_stop_rgb(0.22, brightness, brightness, darkness)
+        lg.add_color_stop_rgb(0.25, brightness, brightness, darkness)
+        lg.add_color_stop_rgb(0.35, darkness, brightness, darkness)
+        lg.add_color_stop_rgb(1.0, darkness, brightness, darkness)
+        # return result
+        return lg
+
     def on_draw(self, widget, cr):
         # number of audio-channels
         channels = len(self.levelrms)
@@ -47,34 +60,11 @@ class AudioLevelDisplay(object):
         peak_px = [self.normalize_db(db) * height for db in self.levelpeak]
         decay_px = [self.normalize_db(db) * height for db in self.leveldecay]
 
-        # setup brightness levels for the different levels
-        bg_fade = 0.25
-        rms_fade = 1.0
-        peak_fade = 0.75
-        decay_invers_fade = 0.5
-
         # setup gradients for all level bars
-        bg_lg = cairo.LinearGradient(0, 0, 0, height)
-        bg_lg.add_color_stop_rgb(0.0, bg_fade, 0, 0)
-        bg_lg.add_color_stop_rgb(0.5, bg_fade, bg_fade, 0)
-        bg_lg.add_color_stop_rgb(1.0, 0, bg_fade, 0)
-
-        rms_lg = cairo.LinearGradient(0, 0, 0, height)
-        rms_lg.add_color_stop_rgb(0.0, rms_fade, 0, 0)
-        rms_lg.add_color_stop_rgb(0.5, rms_fade, rms_fade, 0)
-        rms_lg.add_color_stop_rgb(1.0, 0, rms_fade, 0)
-
-        peak_lg = cairo.LinearGradient(0, 0, 0, height)
-        peak_lg.add_color_stop_rgb(0.0, peak_fade, 0, 0)
-        peak_lg.add_color_stop_rgb(0.5, peak_fade, peak_fade, 0)
-        peak_lg.add_color_stop_rgb(1.0, 0, peak_fade, 0)
-
-        decay_lg = cairo.LinearGradient(0, 0, 0, height)
-        decay_lg.add_color_stop_rgb(
-            0.0, 1, decay_invers_fade, decay_invers_fade)
-        decay_lg.add_color_stop_rgb(0.5, 1, 1, decay_invers_fade)
-        decay_lg.add_color_stop_rgb(
-            1.0, decay_invers_fade, 1, decay_invers_fade)
+        bg_lg = self.gradient(0.25, 0.0, height)
+        rms_lg = self.gradient(1.0, 0.0, height)
+        peak_lg = self.gradient(0.75, 0.0, height)
+        decay_lg = self.gradient(0.0, 0.5, height)
 
         # draw all level bars for all channels
         for channel in range(0, channels):

--- a/voctogui/lib/audioleveldisplay.py
+++ b/voctogui/lib/audioleveldisplay.py
@@ -94,6 +94,12 @@ class AudioLevelDisplay(object):
             cr.set_source(decay_lg)
             cr.fill()
 
+            # draw medium grey margin bar
+            if margin > 0:
+                cr.rectangle(x + channel_width, 0, margin, height)
+                cr.set_source_rgb(0.5, 0.5, 0.5)
+                cr.fill()
+
         # draw db text-markers
         for db in [-40, -20, -10, -5, -4, -3, -2, -1]:
             text = str(db)

--- a/voctogui/lib/audioleveldisplay.py
+++ b/voctogui/lib/audioleveldisplay.py
@@ -50,7 +50,7 @@ class AudioLevelDisplay(object):
         bg_fade = 0.25
         rms_fade = 1.0
         peak_fade = 0.75
-        decay_fade = 0.5
+        decay_invers_fade = 0.5
 
         # setup gradients for all level bars
         bg_lg = cairo.LinearGradient(0, 0, 0, height)
@@ -64,14 +64,14 @@ class AudioLevelDisplay(object):
         rms_lg.add_color_stop_rgb(1.0, 0, rms_fade, 0)
 
         peak_lg = cairo.LinearGradient(0, 0, 0, height)
-        peak_lg.add_color_stop_rgb(0.0, 0.75, 0, 0)
-        peak_lg.add_color_stop_rgb(0.5, 0.75, 0.75, 0)
-        peak_lg.add_color_stop_rgb(1.0, 0, 0.75, 0)
+        peak_lg.add_color_stop_rgb(0.0, peak_fade, 0, 0)
+        peak_lg.add_color_stop_rgb(0.5, peak_fade, peak_fade, 0)
+        peak_lg.add_color_stop_rgb(1.0, 0, peak_fade, 0)
 
         decay_lg = cairo.LinearGradient(0, 0, 0, height)
-        decay_lg.add_color_stop_rgb(0.0, 1, 0.5, 0.5)
-        decay_lg.add_color_stop_rgb(0.5, 1, 1, 0.5)
-        decay_lg.add_color_stop_rgb(1.0, 0.5, 1, 0.5)
+        decay_lg.add_color_stop_rgb(0.0, 1, decay_invers_fade, decay_invers_fade)
+        decay_lg.add_color_stop_rgb(0.5, 1, 1, decay_invers_fade)
+        decay_lg.add_color_stop_rgb(1.0, decay_invers_fade, 1, decay_invers_fade)
 
         # draw all level bars for all channels
         for channel in range(0, channels):

--- a/voctogui/lib/audioleveldisplay.py
+++ b/voctogui/lib/audioleveldisplay.py
@@ -134,7 +134,8 @@ class AudioLevelDisplay(object):
         return max(min(value, max_value), min_value)
 
     def level_callback(self, rms, peak, decay):
-        if self.levelrms != rms or self.levelpeak != peak or self.leveldecay != decay:
+        if (self.levelrms != rms or self.levelpeak != peak or
+                self.leveldecay != decay):
             self.levelrms = rms
             self.levelpeak = peak
             self.leveldecay = decay


### PR DESCRIPTION
Improved CPU usage and look of the audio level display

After a first profiling session with voctogui I realized a CPU usage
peak at audioleveldisplay.py:22(on_draw). This drawing routine uses
move-to and line-to to create a gradient for displaying the audio levels
which I found quite expensive. I replaced it by code which draws four
rectangles for every channel by using cairo gradients which works much
faster.

Sorry for the temporary mess on the master branch where I accidentally committed eight changes which I have already reverted.