### PR TITLE
use GLib.timeout_add rather then GLib.timeout_add_seconds

### DIFF
--- a/voctogui/lib/studioclock.py
+++ b/voctogui/lib/studioclock.py
@@ -11,7 +11,7 @@ class StudioClock(Gtk.ToolItem):
     __gtype_name__ = 'StudioClock'
 
     # set resolution of the update timer in seconds
-    timer_resolution = 0.1
+    timer_resolution = 0.5
     last_draw_time = time.localtime(0)
 
     # init widget
@@ -22,7 +22,7 @@ class StudioClock(Gtk.ToolItem):
         # remember last draw time
         self.last_draw_time = time.time()
         # set up timeout for periodic redraw
-        GLib.timeout_add_seconds(self.timer_resolution, self.do_timeout)
+        GLib.timeout_add(self.timer_resolution * 1000, self.do_timeout)
 
     def do_timeout(self):
         # get current time

--- a/voctogui/lib/warningoverlay.py
+++ b/voctogui/lib/warningoverlay.py
@@ -39,9 +39,6 @@ class VideoWarningOverlay(object):
         w = drawing_area.get_allocated_width()
         h = drawing_area.get_allocated_height()
 
-        self.log.debug('draw_callback: w/h=%u/%u, blink_state=%u',
-                       w, h, self.blink_state)
-
         if self.blink_state:
             cr.set_source_rgba(1.0, 0.0, 0.0, 0.8)
         else:


### PR DESCRIPTION
it seems to stop the lagging in the audio-level widget.
I also reduced the clock-redraw to twice a second, as I don't see a need for redrawing 10 times a second. Second-Accuracy is not really required here anyway.

fixes #218 
