### PR TITLE
Add config options for video-format

### DIFF
--- a/voctocore/default-config.ini
+++ b/voctocore/default-config.ini
@@ -24,6 +24,7 @@ deinterlace = assume-progressive
 ;devicenumber = 0
 ;video_connection = SDI
 ;video_mode = 1080i50
+;video_format = auto
 ;audio_connection = embedded
 ;volume=0.5
 

--- a/voctocore/lib/sources/decklinkavsource.py
+++ b/voctocore/lib/sources/decklinkavsource.py
@@ -27,6 +27,9 @@ class DeckLinkAVSource(AVSource):
         # Video mode, default: 1080i50
         self.vmode = Config.get(section, 'video_mode', fallback='1080i50')
 
+        # Video format, default: auto
+        self.vfmt = Config.get(section, 'video_format', fallback='auto')
+
         self.audiostream_map = self._parse_audiostream_map(section)
         self.log.info("audiostream_map: %s", self.audiostream_map)
 
@@ -130,11 +133,13 @@ class DeckLinkAVSource(AVSource):
             decklinkvideosrc
                 device-number={device}
                 connection={conn}
+                video-format={fmt}
                 mode={mode} !
         """.format(
             device=self.device,
             conn=self.vconn,
-            mode=self.vmode
+            mode=self.vmode,
+            fmt=self.vfmt
         )
 
         if self.has_video:


### PR DESCRIPTION
Video format type to use for decklinkavsources. Default value is set to auto which was automatically in use till now. Not setting this option in the voctocore config doesn't change current behaviour. With adding e.g. `video_format=8bit-argb` to a source section an explicit video format can be chosen if autodetection fails. All possible video formats can be listed via `gst-inspect-1.0 decklinkvideosrc`.