### PR TITLE
VU meters for all audiostreams

### DIFF
--- a/voctogui/default-config.ini
+++ b/voctogui/default-config.ini
@@ -12,6 +12,8 @@ use=true
 [mainvideo]
 # disabled by default because it seems there's an issue, see
 # https://github.com/voc/voctomix/issues/37
+# number of vu meters to display, set vumeter=all to to show VU meters of all audiostreams in gui
+vumeter=1
 playaudio=false
 
 [videodisplay]

--- a/voctogui/lib/videodisplay.py
+++ b/voctogui/lib/videodisplay.py
@@ -27,8 +27,7 @@ class VideoDisplay(object):
 
         audiostreams = int(Config.get('mix', 'audiostreams'))
 
-        if (Config.has_option('mainvideo', 'vumeter')) \
-                and (Config.get('mainvideo', 'vumeter') != 'all') \
+        if (Config.get('mainvideo', 'vumeter') != 'all') \
                 and int(Config.get('mainvideo', 'vumeter')) < audiostreams:
             audiostreams = int(Config.get('mainvideo', 'vumeter'))
 
@@ -124,7 +123,7 @@ class VideoDisplay(object):
                 """.format(audiostream=audiostream)
 
                 # If Playback is requested, push fo pulseaudio
-                if play_audio:
+                if play_audio and audiostream == 0:
                     pipeline += """
                         pulsesink
                     """
@@ -176,9 +175,7 @@ class VideoDisplay(object):
         self.log.debug('Error-Details: #%u: %s', error.code, debug)
 
     def on_level(self, bus, msg):
-        p = re.compile('(lvl_)([0-9])')
-        m = p.match(msg.src.name)
-        if not(m):
+        if not(msg.src.name.startswith('lvl_')):
             return
 
         if msg.type != Gst.MessageType.ELEMENT:
@@ -187,5 +184,5 @@ class VideoDisplay(object):
         rms = msg.get_structure().get_value('rms')
         peak = msg.get_structure().get_value('peak')
         decay = msg.get_structure().get_value('decay')
-        stream = int(m.group(2))
+        stream = int(msg.src.name[4])
         self.level_callback(rms, peak, decay, stream)

--- a/voctogui/ui/voctogui.ui
+++ b/voctogui/ui/voctogui.ui
@@ -255,7 +255,7 @@
             </child>
             <child>
               <object class="AudioLevelDisplay" id="audiolevel_main">
-                <property name="width_request">30</property>
+                <property name="width_request">100</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_right">5</property>

--- a/voctogui/ui/voctogui.ui
+++ b/voctogui/ui/voctogui.ui
@@ -255,7 +255,6 @@
             </child>
             <child>
               <object class="AudioLevelDisplay" id="audiolevel_main">
-                <property name="width_request">100</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_right">5</property>


### PR DESCRIPTION
This commit adds the possibility to show VU meters for all audiostreams. `vumeter=1` in `voctogui.ini` mimics the previous behaviour of showing only the first stereo pair. `vumeter=all` will show a VU meter for every configured audiostream and audiochannel without having to specify an explicit number. `vumeter=n` will show only show vumeters for all audio channels of first `n` audiostreams.