### PR TITLE
voctolight: Refactor into a plugin architecture

### DIFF
--- a/example-scripts/voctolight/README.md
+++ b/example-scripts/voctolight/README.md
@@ -1,0 +1,9 @@
+# voctolight
+
+Application for running a Tally Light for Voctomix.
+
+## Plugins
+
+* `rpi_gpio`: Use GPIO pins on Raspberry Pi
+* `stdout`: Write tally light state to standard output (useful for testing)
+

--- a/example-scripts/voctolight/default-config.ini
+++ b/example-scripts/voctolight/default-config.ini
@@ -1,7 +1,25 @@
 [server]
+;; Must point at your mixer's IP / hostname
 host=localhost
 
 [light]
-cam=cam2
+;; Camera name to use, case sensitive.
+cam=Camera
+
+;; Plugin to use for output, choose one:
+
+;; Write tally light state to stdout
+plugin=stdout
+
+;; Raspberry Pi GPIO
+;;
+;; Requires RPi.GPIO
+; plugin=rpi_gpio
+
+[rpi]
+;; GPIO that has the desired light
 gpio_red=11
+
+;; GPIOs to reset/initialise
 gpios=11,12,13
+

--- a/example-scripts/voctolight/lib/plugins/all_plugins.py
+++ b/example-scripts/voctolight/lib/plugins/all_plugins.py
@@ -1,0 +1,19 @@
+from .base_plugin import BasePlugin
+from .rpi_gpio import RpiGpio
+from .stdout import Stdout
+
+PLUGINS = {
+    'rpi_gpio': RpiGpio,
+    'stdout': Stdout,
+}
+
+
+def get_plugin(config) -> BasePlugin:
+    """Creates an instance of a plugin named in Voctolight's configuration file."""
+    plugin_name = config.get('light', 'plugin')
+    plugin_cls = PLUGINS.get(plugin_name, None)
+
+    if plugin_cls is None:
+        raise ValueError(f'{plugin_name} is not a valid plugin name')
+
+    return plugin_cls(config)

--- a/example-scripts/voctolight/lib/plugins/base_plugin.py
+++ b/example-scripts/voctolight/lib/plugins/base_plugin.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+__all__ = ['BasePlugin']
+
+
+class BasePlugin(ABC):
+    """An abstract plugin class, that all other plugins inherit from."""
+
+    def __init__(self, config):
+        ...
+
+    @abstractmethod
+    def tally_on(self) -> None:
+        """Called when the tally light should be turned on."""
+        ...
+
+    @abstractmethod
+    def tally_off(self) -> None:
+        """Called when the tally light should be turned off."""
+        ...

--- a/example-scripts/voctolight/lib/plugins/rpi_gpio.py
+++ b/example-scripts/voctolight/lib/plugins/rpi_gpio.py
@@ -1,0 +1,33 @@
+"""
+Plugin to provide a tally light interface for a Raspberry Pi's GPIO.
+
+It requires RPi.GPIO.
+"""
+
+from .base_plugin import BasePlugin
+
+try:
+    import RPi.GPIO as GPIO
+    GPIO.setmode(GPIO.BOARD)
+except ImportError:
+    # We are probably not running on a Raspberry Pi.
+    GPIO = None
+
+__all__ = ['RpiGpio']
+
+class RpiGpio(BasePlugin):
+    def __init__(self, config):
+        if not GPIO:
+            raise NotImplementedError('RpiGpio will not work on this platform. Is RPi.GPIO installed?')
+
+        all_gpios = [int(i) for i in config.get('rpi', 'gpios').split(',')]
+        self.gpio_port = int(config.get('rpi', 'gpio_red'))
+
+        GPIO.setup(all_gpios, GPIO.OUT)
+        GPIO.output(all_gpios, GPIO.HIGH)
+
+    def tally_on(self):
+        GPIO.output(self.gpio_port, GPIO.LOW)
+
+    def tally_off(self):
+        GPIO.output(self.gpio_port, GPIO.HIGH)

--- a/example-scripts/voctolight/lib/plugins/stdout.py
+++ b/example-scripts/voctolight/lib/plugins/stdout.py
@@ -1,0 +1,16 @@
+"""
+Plugin to provide a tally light interface via stdout.
+
+This is an example that can be used to build other plugins.
+"""
+
+from .base_plugin import BasePlugin
+
+__all__ = ['Stdout']
+
+class Stdout(BasePlugin):
+    def tally_on(self):
+        print('Tally light on')
+
+    def tally_off(self):
+        print('Tally light off')

--- a/example-scripts/voctolight/testlight.py
+++ b/example-scripts/voctolight/testlight.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Test driver for Voctolight plugins.
+from lib.config import Config
+from lib.plugins.all_plugins import get_plugin
+
+def main():
+    plugin = get_plugin(Config)
+
+    try:
+        while True:
+            print('Tally light on. Press ENTER to turn off, ^C to stop.')
+            plugin.tally_on()
+            input()
+            print('Tally light off. Press ENTER to turn on, ^C to stop.')
+            plugin.tally_off()
+            input()
+    except KeyboardInterrupt:
+        pass
+
+if __name__ in '__main__':
+    main()


### PR DESCRIPTION
* Previous Raspberry Pi support becomes `rpi_gpio` plugin
* New plugin: `stdout` (which prints the tally light status to stdout)
* Add test program for running without voctomix

This allows multiple types of tally light, not just Raspberry Pi... (see #236)