### PR TITLE
voctolight: Add tomu_simple_led tally light

### DIFF
--- a/example-scripts/voctolight/README.md
+++ b/example-scripts/voctolight/README.md
@@ -6,4 +6,5 @@ Application for running a Tally Light for Voctomix.
 
 * `rpi_gpio`: Use GPIO pins on Raspberry Pi
 * `stdout`: Write tally light state to standard output (useful for testing)
+* `tomu_simple_led`: Use [tomu simple_usb as a tally light](https://github.com/im-tomu/tomu-samples/tree/master/usb_simple)
 

--- a/example-scripts/voctolight/README.md
+++ b/example-scripts/voctolight/README.md
@@ -1,0 +1,9 @@
+# voctolight
+
+Application for running a Tally Light for Voctomix.
+
+## Plugins
+
+* `rpi_gpio`: Use GPIO pins on Raspberry Pi
+* `stdout`: Write tally light state to standard output (useful for testing)
+

--- a/example-scripts/voctolight/default-config.ini
+++ b/example-scripts/voctolight/default-config.ini
@@ -1,7 +1,25 @@
 [server]
+;; Must point at your mixer's IP / hostname
 host=localhost
 
 [light]
-cam=cam2
+;; Camera name to use, case sensitive.
+cam=Camera
+
+;; Plugin to use for output, choose one:
+
+;; Write tally light state to stdout
+plugin=stdout
+
+;; Raspberry Pi GPIO
+;;
+;; Requires RPi.GPIO
+; plugin=rpi_gpio
+
+[rpi]
+;; GPIO that has the desired light
 gpio_red=11
+
+;; GPIOs to reset/initialise
 gpios=11,12,13
+

--- a/example-scripts/voctolight/default-config.ini
+++ b/example-scripts/voctolight/default-config.ini
@@ -16,10 +16,28 @@ plugin=stdout
 ;; Requires RPi.GPIO
 ; plugin=rpi_gpio
 
+;; Tomu Simple LED
+;;
+;; Requires pyusb
+;;
+;; usb_simple application required from:
+;; https://github.com/im-tomu/tomu-samples/tree/master/usb_simple
+; plugin=tomu_simple_led
+
 [rpi]
 ;; GPIO that has the desired light
 gpio_red=11
 
 ;; GPIOs to reset/initialise
 gpios=11,12,13
+
+[tomu]
+;; Value to send to usb_simple is a bitmask:
+;;
+;;   0: no light
+;;   1: green light
+;;   2: red light
+;;   3: both lights
+on=2
+off=0
 

--- a/example-scripts/voctolight/lib/plugins/all_plugins.py
+++ b/example-scripts/voctolight/lib/plugins/all_plugins.py
@@ -1,10 +1,12 @@
 from .base_plugin import BasePlugin
 from .rpi_gpio import RpiGpio
 from .stdout import Stdout
+from .tomu_simple_led import TomuSimpleLed
 
 PLUGINS = {
     'rpi_gpio': RpiGpio,
     'stdout': Stdout,
+    'tomu_simple_led': TomuSimpleLed,
 }
 
 

--- a/example-scripts/voctolight/lib/plugins/all_plugins.py
+++ b/example-scripts/voctolight/lib/plugins/all_plugins.py
@@ -1,0 +1,19 @@
+from .base_plugin import BasePlugin
+from .rpi_gpio import RpiGpio
+from .stdout import Stdout
+
+PLUGINS = {
+    'rpi_gpio': RpiGpio,
+    'stdout': Stdout,
+}
+
+
+def get_plugin(config) -> BasePlugin:
+    """Creates an instance of a plugin named in Voctolight's configuration file."""
+    plugin_name = config.get('light', 'plugin')
+    plugin_cls = PLUGINS.get(plugin_name, None)
+
+    if plugin_cls is None:
+        raise ValueError(f'{plugin_name} is not a valid plugin name')
+
+    return plugin_cls(config)

--- a/example-scripts/voctolight/lib/plugins/base_plugin.py
+++ b/example-scripts/voctolight/lib/plugins/base_plugin.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+__all__ = ['BasePlugin']
+
+
+class BasePlugin(ABC):
+    """An abstract plugin class, that all other plugins inherit from."""
+
+    def __init__(self, config):
+        ...
+
+    @abstractmethod
+    def tally_on(self) -> None:
+        """Called when the tally light should be turned on."""
+        ...
+
+    @abstractmethod
+    def tally_off(self) -> None:
+        """Called when the tally light should be turned off."""
+        ...

--- a/example-scripts/voctolight/lib/plugins/rpi_gpio.py
+++ b/example-scripts/voctolight/lib/plugins/rpi_gpio.py
@@ -1,0 +1,33 @@
+"""
+Plugin to provide a tally light interface for a Raspberry Pi's GPIO.
+
+It requires RPi.GPIO.
+"""
+
+from .base_plugin import BasePlugin
+
+try:
+    import RPi.GPIO as GPIO
+    GPIO.setmode(GPIO.BOARD)
+except ImportError:
+    # We are probably not running on a Raspberry Pi.
+    GPIO = None
+
+__all__ = ['RpiGpio']
+
+class RpiGpio(BasePlugin):
+    def __init__(self, config):
+        if not GPIO:
+            raise NotImplementedError('RpiGpio will not work on this platform. Is RPi.GPIO installed?')
+
+        all_gpios = [int(i) for i in config.get('rpi', 'gpios').split(',')]
+        self.gpio_port = int(config.get('rpi', 'gpio_red'))
+
+        GPIO.setup(all_gpios, GPIO.OUT)
+        GPIO.output(all_gpios, GPIO.HIGH)
+
+    def tally_on(self):
+        GPIO.output(self.gpio_port, GPIO.LOW)
+
+    def tally_off(self):
+        GPIO.output(self.gpio_port, GPIO.HIGH)

--- a/example-scripts/voctolight/lib/plugins/stdout.py
+++ b/example-scripts/voctolight/lib/plugins/stdout.py
@@ -1,0 +1,16 @@
+"""
+Plugin to provide a tally light interface via stdout.
+
+This is an example that can be used to build other plugins.
+"""
+
+from .base_plugin import BasePlugin
+
+__all__ = ['Stdout']
+
+class Stdout(BasePlugin):
+    def tally_on(self):
+        print('Tally light on')
+
+    def tally_off(self):
+        print('Tally light off')

--- a/example-scripts/voctolight/lib/plugins/tomu_simple_led.py
+++ b/example-scripts/voctolight/lib/plugins/tomu_simple_led.py
@@ -1,0 +1,30 @@
+# Makes a tomu.im USB Simple sample as a tally light.
+# https://github.com/im-tomu/tomu-samples/tree/master/usb_simple
+
+from .base_plugin import BasePlugin
+
+try:
+    import usb.core
+except ImportError:
+    usb = None
+
+
+class TomuSimpleLed(BasePlugin):
+    def __init__(self, config):
+        if not usb:
+            raise ValueError('USB support not available. Install pyusb')
+
+        self.on = int(config.get('tomu', 'on'))
+        self.off = int(config.get('tomu', 'off'))
+
+        self.device = usb.core.find(idVendor=0x1209, idProduct=0x70b1)
+        if self.device is None:
+            raise ValueError('Device not found, flash usb_simple on the tomu.')
+
+        self.device.set_configuration()
+
+    def tally_on(self):
+        self.device.ctrl_transfer(0x40, 0, self.on, 0, '')
+
+    def tally_off(self):
+        self.device.ctrl_transfer(0x40, 0, self.off, 0, '')

--- a/example-scripts/voctolight/testlight.py
+++ b/example-scripts/voctolight/testlight.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Test driver for Voctolight plugins.
+from lib.config import Config
+from lib.plugins.all_plugins import get_plugin
+
+def main():
+    plugin = get_plugin(Config)
+
+    try:
+        while True:
+            print('Tally light on. Press ENTER to turn off, ^C to stop.')
+            plugin.tally_on()
+            input()
+            print('Tally light off. Press ENTER to turn on, ^C to stop.')
+            plugin.tally_off()
+            input()
+    except KeyboardInterrupt:
+        pass
+
+if __name__ in '__main__':
+    main()


### PR DESCRIPTION
Based on #235 (plugin architecture for voctolight).

This adds a plugin, `tomu_simple_led`, to turn a [Tomu](https://tomu.im) running [usb_simple](https://github.com/im-tomu/tomu-samples/tree/master/usb_simple) into a tally light.

Photo of use at PyConAU 2018 (courtesy of @oheydrew):

![img_20180826_113823](https://user-images.githubusercontent.com/246847/49685055-eabc2180-fb30-11e8-8ee7-ca158f0524f0.jpg)

There are configuration options to use any combination of the red and/or green LEDs for live/not-live state.