### PR TITLE
replaced deprecated colon syntax for panning

### DIFF
--- a/example-scripts/ffmpeg/stream-hd-to-youtube.sh
+++ b/example-scripts/ffmpeg/stream-hd-to-youtube.sh
@@ -16,7 +16,7 @@ ffmpeg -y -nostdin \
 	-preset:v:0 veryfast \
 	\
 	-ac 1 -c:a aac -b:a 96k -ar 44100 \
-	-map 0:a -filter:a:0 pan=mono:c0=FL \
+	-map 0:a -filter:a:0 pan='mono|c0=FL' \
 	-ac:a:2 2 \
 	\
 	-y -f flv rtmp://a.rtmp.youtube.com/live2/YOUR_STREAM_KEY

--- a/example-scripts/ffmpeg/stream-hd.sh
+++ b/example-scripts/ffmpeg/stream-hd.sh
@@ -16,7 +16,7 @@ ffmpeg -y -nostdin \
 	-preset:v:0 veryfast \
 	\
 	-ac 1 -c:a aac -b:a 96k -ar 44100 \
-	-map 0:a -filter:a:0 pan=mono:c0=FL \
+	-map 0:a -filter:a:0 pan='mono|c0=FL' \
 	-ac:a:2 2 \
 	\
 	-y -f flv rtmp://127.0.0.1:1935/stream/voctomix_hd

--- a/example-scripts/ffmpeg/stream-sd.sh
+++ b/example-scripts/ffmpeg/stream-sd.sh
@@ -16,7 +16,7 @@ ffmpeg -y -nostdin \
 	-preset:v:0 veryfast \
 	\
 	-ac 1 -c:a aac -b:a 96k -ar 44100 \
-	-map 0:a -filter:a:0 pan=mono:c0=FL \
+	-map 0:a -filter:a:0 pan='mono|c0=FL' \
 	-ac:a:2 2 \
 	\
 	-y -f flv rtmp://127.0.0.1:1935/stream/voctomix_hd


### PR DESCRIPTION
FFmpeg 4.1-1 as distributed in Debian Testing now won't start when using the current colon-based (`:`) syntax, so I replaced it with the new pipe-based (`|`) syntax, which solved the issue, and it has been already present within the FFmpeg examples, see `stream-combined.sh`