### PR TITLE
Clear signal_watch to avoid unix fd leak when pipeline is destroyed.

### DIFF
--- a/voctocore/lib/sources/tcpavsource.py
+++ b/voctocore/lib/sources/tcpavsource.py
@@ -104,6 +104,7 @@ class TCPAVSource(AVSource, TCPSingleConnection):
 
     def disconnect(self):
         self.pipeline.set_state(Gst.State.NULL)
+        self.pipeline.bus.remove_signal_watch()
         self.pipeline = None
         self.close_connection()
 


### PR DESCRIPTION
Few days ago I encoutered the problem reported here : https://github.com/voc/voctomix/issues/172

After some investigation and thanks to `strace` I found out that the problem may comes from improper handling of pipeline destruction when a signal_watcher is set.

Removing it manually before the unref of the pipeline should fix the issue.