### PR TITLE
voctocore: cropping in lecture mode

### DIFF
--- a/vocto/transitions.py
+++ b/vocto/transitions.py
@@ -183,7 +183,7 @@ class Transition:
         result = "\t%s = %s -> %s:\n" % (self.name(),
                                       self.begin().name, self.end().name)
         # add table title
-        result += "\tNo. %s\n" % Composite.str_title()
+        result += "\tNo. %s\n" % Composite.str_title(self)
         # add composites until flipping point
         for i in range(self.frames()):
             if (not logKeyFramesOnly) or self.A(i).key:

--- a/voctocore/lib/videomix.py
+++ b/voctocore/lib/videomix.py
@@ -113,7 +113,7 @@ class VideoMix(object):
 
         self.log.debug('Initializing Mixer-State')
         # initialize pipeline bindings for all sources
-        self.bgScene = Scene(self.bgSources, pipeline, self.transitions.fps, 0)
+        self.bgScene = Scene(self.bgSources, pipeline, self.transitions.fps, 0, cropping=False)
         self.scene = Scene(self.sources, pipeline, self.transitions.fps, len(self.bgSources))
         self.compositeMode = None
         self.sourceA = None

--- a/voctocore/lib/videomix.py
+++ b/voctocore/lib/videomix.py
@@ -90,7 +90,7 @@ class VideoMix(object):
         for idx, name in enumerate(self.sources):
             self.bin += """
                 video-{name}.
-                ! queue
+                ! videobox
                     name=cropper-{name}
                 ! queue
                     max-size-time=3000000000
@@ -113,8 +113,8 @@ class VideoMix(object):
 
         self.log.debug('Initializing Mixer-State')
         # initialize pipeline bindings for all sources
-        self.bgScene = Scene(self.bgSources, pipeline, self.transitions.fps, 0, cropping=False)
-        self.scene = Scene(self.sources, pipeline, self.transitions.fps, len(self.bgSources), cropping=False)
+        self.bgScene = Scene(self.bgSources, pipeline, self.transitions.fps, 0)
+        self.scene = Scene(self.sources, pipeline, self.transitions.fps, len(self.bgSources))
         self.compositeMode = None
         self.sourceA = None
         self.sourceB = None


### PR DESCRIPTION
fixes #305

Removing videobox and replacing it with a queue broke lecture mode. The element is necessary at that pont in the chain to enable correct cropping of sources in composite modes.