### PR TITLE
voctocore: output gstreamer debug message on pipeline error

### DIFF
--- a/voctocore/lib/pipeline.py
+++ b/voctocore/lib/pipeline.py
@@ -195,6 +195,7 @@ class Pipeline(object):
 
     def on_error(self, bus, message):
         (error, debug) = message.parse_error()
+        self.log.debug(debug)
         self.log.error("GStreamer pipeline element '%s' signaled an error #%u: %s" % (message.src.name, error.code, error.message) )
         sys.exit(-1)
 


### PR DESCRIPTION
Just a very small change, but should improve pipeline debuggability by outputting the actual debug message and not only a nondescriptive summary.
```
   DEBUG Pipeline: ../gst/matroska/matroska-mux.c(1130): gst_matroska_mux_video_pad_setcaps (): /GstPipeline:pipeline0/GstBin:AVRawOutput-mix/GstMatroskaMux:mux-mix:
Caps changes are not supported by Matroska
Current: `video/x-raw, format=(string)I420, width=(int)1920, height=(int)1080, framerate=(fraction)25/1, pixel-aspect-ratio=(fraction)1/1, interlace-mode=(string)progressive, chroma-site=(string)jpeg, colori
metry=(string)bt601`
New: `video/x-raw, format=(string)I420, width=(int)1920, height=(int)1080, framerate=(fraction)25/1, pixel-aspect-ratio=(fraction)1/1, interlace-mode=(string)progressive, chroma-site=(string)mpeg2, colorimet
ry=(string)bt709`
   ERROR Pipeline: GStreamer pipeline element 'mux-mix' signaled an error #10: Could not multiplex stream.
 
```
Previously only the ERROR-Line was printed, now, the accompnying more verbose DEBUG-line too if verbosity is at triple-v.