### PR TITLE
gstreamer release 1.18 deprecated the yadif plugin.

### DIFF
--- a/voctocore/lib/sources/avsource.py
+++ b/voctocore/lib/sources/avsource.py
@@ -183,7 +183,7 @@ class AVSource(object, metaclass=ABCMeta):
         source_mode = Config.getSourceScan(self.name)
 
         if source_mode == "interlaced":
-            return "videoconvert ! yadif mode=interlaced"
+            return "videoconvert ! deinterlace"
         elif source_mode == "psf":
             return "capssetter " \
                    "caps=video/x-raw,interlace-mode=progressive"


### PR DESCRIPTION
Hello from DebConf24! It seems our capture cards only do 1080i so we're stuck with deinterlacing for now :)

Sadly, the current code was crashing for us, as the yadif plugin has been deprecated in gstreamer 1.18. From the [1.18 release page](https://gstreamer.freedesktop.org/releases/1.18/):

> The yadif video deinterlacing plugin from gst-plugins-bad, which was one of the few GPL licensed plugins, has been removed in favour of deinterlace method=yadif.

We did try to use `deinterlace method=yadif` instead of the default, but it was choppy and much worse.