### PR TITLE
Improve voctocore's default config paths

### DIFF
--- a/voctocore/lib/config.py
+++ b/voctocore/lib/config.py
@@ -6,6 +6,7 @@ import os.path
 import re
 from configparser import DuplicateSectionError
 from datetime import date, datetime, timedelta
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from lib.args import Args
@@ -343,8 +344,18 @@ def load():
 
     Config = VoctocoreConfigParser()
 
-    config_file_name = Args.ini_file if Args.ini_file else os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), '../default-config.ini')
+    home_ini_file = os.path.join(Path.home(), '.config/voctomix/voctocore.ini')
+    etc_ini_file = '/etc/voctomix/voctocore.ini'
+    default_ini_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                    '../default-config.ini')
+    if Args.ini_file:
+        config_file_name = Args.ini_file
+    elif Path(home_ini_file).is_file():
+        config_file_name = home_ini_file
+    elif Path(etc_ini_file).is_file():
+        config_file_name = etc_ini_file
+    else:
+        config_file_name = default_ini_file
     readfiles = Config.read([config_file_name])
 
     log = logging.getLogger('ConfigParser')


### PR DESCRIPTION
Commit 25f0da2ca9af0f2047a57a6ea9466c9a4a08ff38 removed the ability to load configuration from /etc/voctomix/voctocore.ini.

This patch adds a new configuration path hierarchy, which goes:

- configuration file from the CLI (-i foo.ini)
- $HOME/.config/voctomix/voctocore.ini
- /etc/voctomic/voctocore.ini
- default-config.ini