### PR TITLE
Add sbs preset for 2 cameras

### DIFF
--- a/voctogui/lib/presetcontroller.py
+++ b/voctogui/lib/presetcontroller.py
@@ -89,17 +89,24 @@ class PresetController(object):
 
         if "sbs" in composites:
             for sourceA in sources_composites:
-                if sourceA not in Config.getLiveSources():
-                    continue
                 for sourceB in sources_composites:
-                    if sourceB not in Config.getLiveSources():
+                    if ((sourceB not in Config.getLiveSources() and
+                         sourceA in Config.getLiveSources()) or
+                        (sourceA not in Config.getLiveSources() and
+                         sourceB not in Config.getLiveSources() and
+                         sourceB > sourceA)):
                         button_name = f"preset_sbs_{sourceA}_{sourceB}"
                         buttons[f"{button_name}.name"] = (
                             f"{sourceA}\n{sourceB}"
                         )
-                        buttons[f"{button_name}.icon"] = (
-                            "side-by-side.svg"
-                        )
+                        if sourceA == 'slides':
+                            buttons[f"{button_name}.icon"] = (
+                                "side-by-side.svg"
+                            )
+                        else:
+                            buttons[f"{button_name}.icon"] = (
+                                "side-by-side-cams.svg"
+                            )
                         try:
                             buttons[f"{button_name}.key"] = keybindings[idx]
                             idx += 1

--- a/voctogui/ui/side-by-side-cams.svg
+++ b/voctogui/ui/side-by-side-cams.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="48"
+   id="svg3052"
+   version="1.1"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="side-by-side-cams.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3054" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16.213695"
+     inkscape:cx="31.979139"
+     inkscape:cy="21.525013"
+     inkscape:document-units="px"
+     inkscape:current-layer="g26166"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1022"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata3057">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1004.3622)">
+    <g
+       id="g26166"
+       transform="translate(71.858806,41.649805)">
+      <g
+         style="fill:#000000"
+         id="g8232"
+         transform="matrix(0.33818321,0,0,0.33818321,-160.47192,950.01462)">
+        <rect
+           rx="19.285715"
+           ry="19.285713"
+           y="50.17815"
+           x="275.3829"
+           height="116.67266"
+           width="162.79439"
+           id="rect8234"
+           style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6.61302567;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         transform="matrix(0.16891997,0,0,0.16891997,-114.25311,968.38213)"
+         id="g8202">
+        <rect
+           style="opacity:1;fill:#dcdcdc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6.61303;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect8204"
+           width="162.79439"
+           height="116.67266"
+           x="444.02493"
+           y="50.178146"
+           ry="19.285713"
+           rx="19.285715" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8206"
+           d="m 576.04963,166.85081 v -11.80915 c 0,-1.76639 -0.17797,-3.48877 -0.51665,-5.15223 -0.33866,-1.66346 -0.8378,-3.26758 -1.48147,-4.79444 -0.64366,-1.52685 -1.43187,-2.97676 -2.34685,-4.33334 -0.91498,-1.35657 -1.95757,-2.62016 -3.11018,-3.77278 -1.15262,-1.15262 -2.41492,-2.19392 -3.7715,-3.1089 -1.35657,-0.91497 -2.80777,-1.70318 -4.33463,-2.34685 -1.52686,-0.64366 -3.12969,-1.1428 -4.79315,-1.48147 -1.66346,-0.33867 -3.38712,-0.51664 -5.15351,-0.51664 h -47.23535 c -1.76638,0 -3.49005,0.17797 -5.1535,0.51664 -1.66346,0.33867 -3.26759,0.83781 -4.79445,1.48147 -1.52686,0.64367 -2.97676,1.43188 -4.33334,2.34685 -1.35658,0.91498 -2.61888,1.95628 -3.77149,3.1089 -1.15262,1.15262 -2.19521,2.41621 -3.11019,3.77278 -0.91498,1.35658 -1.70318,2.80649 -2.34685,4.33334 -0.64366,1.52686 -1.1428,3.13098 -1.48147,4.79444 -0.33867,1.66346 -0.51664,3.38584 -0.51664,5.15223 v 11.80915 z"
+           style="opacity:1;fill:#e9967a;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6.61303;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <circle
+           r="22.437052"
+           cy="99.067307"
+           cx="526.21539"
+           id="circle8208"
+           style="opacity:1;fill:#ffe4b5;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6.61303;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         transform="matrix(0.16891997,0,0,0.16891997,-142.90639,968.38213)"
+         id="g8202-3">
+        <rect
+           style="opacity:1;fill:#dcdcdc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6.61303;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect8204-6"
+           width="162.79439"
+           height="116.67266"
+           x="444.02493"
+           y="50.178146"
+           ry="19.285713"
+           rx="19.285715" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8206-7"
+           d="m 576.04963,166.85081 v -11.80915 c 0,-1.76639 -0.17797,-3.48877 -0.51665,-5.15223 -0.33866,-1.66346 -0.8378,-3.26758 -1.48147,-4.79444 -0.64366,-1.52685 -1.43187,-2.97676 -2.34685,-4.33334 -0.91498,-1.35657 -1.95757,-2.62016 -3.11018,-3.77278 -1.15262,-1.15262 -2.41492,-2.19392 -3.7715,-3.1089 -1.35657,-0.91497 -2.80777,-1.70318 -4.33463,-2.34685 -1.52686,-0.64366 -3.12969,-1.1428 -4.79315,-1.48147 -1.66346,-0.33867 -3.38712,-0.51664 -5.15351,-0.51664 h -47.23535 c -1.76638,0 -3.49005,0.17797 -5.1535,0.51664 -1.66346,0.33867 -3.26759,0.83781 -4.79445,1.48147 -1.52686,0.64367 -2.97676,1.43188 -4.33334,2.34685 -1.35658,0.91498 -2.61888,1.95628 -3.77149,3.1089 -1.15262,1.15262 -2.19521,2.41621 -3.11019,3.77278 -0.91498,1.35658 -1.70318,2.80649 -2.34685,4.33334 -0.64366,1.52686 -1.1428,3.13098 -1.48147,4.79444 -0.33867,1.66346 -0.51664,3.38584 -0.51664,5.15223 v 11.80915 z"
+           style="opacity:1;fill:#e9967a;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6.61303;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <circle
+           r="22.437052"
+           cy="99.067307"
+           cx="526.21539"
+           id="circle8208-5"
+           style="opacity:1;fill:#ffe4b5;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6.61303;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
For DebConfs, we often want to have 2 cameras side-by-side. It's useful for BoFs and for the Q&A period, when you get a camera on the presenter and on the person asking a question.

This patch adds that preset + a new button.

In general, this seems pretty hacky? Not sure if you actually want to merge this...

What would be great is if there was a configurable way to set presets, instead of having them hardcoded :)