### PR TITLE
just enough ini so voctocore can run.

### DIFF
--- a/configs/2.0/minimal.ini
+++ b/configs/2.0/minimal.ini
@@ -1,0 +1,19 @@
+[mix]
+sources = CAM1,CAM2
+
+[previews]
+; enable previews so we can see something in VOC2GUI
+# enabled = false
+
+; enable live preview so we can see the blinder working
+# live = false
+
+videocaps=video/x-raw,width=1024,height=576,framerate=25/1
+
+[composites]
+; fullscreen source B is full transparent
+FULL.alpha-b            = 0
+
+[transitions]
+; unique name           =  ms, from / [... /] to
+FADE                    = 750, FULL / FULL


### PR DESCRIPTION
When doing R&D and testing automation and orchestration (whatever that means) it can be handy to have a config that is enough to get core up and running.  

put minimal.ini as  /etc/voctomix/voctocore.in 

```
$ voctocore -vv
...
    INFO Pipeline: pipeline launched successfuly
    INFO AudioMix: Updating mixer state
    INFO VideoMix: Request composite full(CAM1,CAM2)
    INFO Voctocore: Running. Waiting for connections....
    INFO Scene: Pushing 1 frame(s) to source 'CAM1' at time 14ms
    INFO Scene: Pushing 1 frame(s) to source 'CAM2' at time 14ms
```


