### PR TITLE
only use vaapi decode on the client if vaapi rendering is enabled

### DIFF
--- a/vocto/video_codecs.py
+++ b/vocto/video_codecs.py
@@ -117,10 +117,14 @@ def construct_video_encoder_pipeline(section):
     return pipeline
 
 
-def construct_video_decoder_pipeline(section):
+def construct_video_decoder_pipeline(section, videosystem=None):
     decoder = Config.getVideoDecoder(section)
     codec, options = Config.getVideoCodec(section)
-    if decoder == 'vaapi':
+    if videosystem == 'vaapi':
+        return vaapi_decoders[codec]
+    elif videosystem is not None:
+        return cpu_decoders[codec]
+    elif decoder == 'vaapi':
         return vaapi_decoders[codec]
     elif decoder == 'cpu':
         return cpu_decoders[codec]

--- a/voctogui/lib/videodisplay.py
+++ b/voctogui/lib/videodisplay.py
@@ -37,6 +37,7 @@ class VideoDisplay(object):
                            host=Config.getHost(),
                            port=port)
 
+        videosystem = Config.getVideoSystem()
         if Config.getPreviewsEnabled():
             self.log.info('using encoded previews instead of raw-video')
 
@@ -46,7 +47,7 @@ class VideoDisplay(object):
                     name=queue-video-{name}
                 ! {video_decoder}
                 """.format(name=name,
-                           video_decoder=construct_video_decoder_pipeline('previews'))
+                           video_decoder=construct_video_decoder_pipeline('previews', videosystem))
 
         else:
             video_decoder = None
@@ -77,7 +78,6 @@ class VideoDisplay(object):
                 """.format(name=name)
 
         # Video Display
-        videosystem = Config.getVideoSystem()
         self.log.debug('Configuring for Video-System %s', videosystem)
 
         if videosystem == 'gl':


### PR DESCRIPTION
Often enough we want to use vaapi encoding on the server, but a client may not support vaapi decoding. Ideally we'd decouple these entirely.

For now it's enough to couple client-side vaapi decoding and vaapi video rendering, as one doesn't make sense without the other (the additional GPU-RAM roundtrips destroy any potential performance benefits anyway).