### PR TITLE
register preset hotkeys

### DIFF
--- a/voctogui/lib/presetcontroller.py
+++ b/voctogui/lib/presetcontroller.py
@@ -21,7 +21,9 @@ class PresetController(object):
 
         presets = Config.getPresetOptions()
         defaults_b = Config.getVideoSources()
+
         accelerators = Gtk.AccelGroup()
+        win.add_accel_group(accelerators)
 
         buttons = {}
         self.button_to_composites = {}


### PR DESCRIPTION
Accelerator Groups need to be registered on the window to be able to react to key presses.

We already do this for all other toolbars, but not for presets.