### PR TITLE
Local Program Output improvements

### DIFF
--- a/vocto/config.py
+++ b/vocto/config.py
@@ -424,6 +424,9 @@ class VocConfigParser(ConfigParser):
     def getProgramOutputEnabled(self):
         return self.getboolean('programoutput', 'enabled', fallback=False)
 
+    def getProgramOutputSource(self):
+        return self.get('programoutput', 'source', fallback="mix")
+
     def getProgramOutputVideoSink(self):
         return self.get('programoutput', 'videosink', fallback="autovideosink")
 

--- a/voctocore/lib/pipeline.py
+++ b/voctocore/lib/pipeline.py
@@ -87,9 +87,9 @@ class Pipeline(object):
 
         # add localui
         if Config.getProgramOutputEnabled():
-            pgmout = ProgramOutputSink("mix", Port.MIX_OUT, use_audio_mix=True)
+            pgmout = ProgramOutputSink(Config.getProgramOutputSource(), Port.MIX_OUT, use_audio_mix=True)
             self.bins.append(pgmout)
-            self.ports.append(Port('mix', pgmout))
+            self.ports.append(Port(Config.getProgramOutputSource(), pgmout))
 
         # create mix preview TCP output
         if Config.getPreviewsEnabled():

--- a/voctocore/lib/program_output.py
+++ b/voctocore/lib/program_output.py
@@ -27,7 +27,7 @@ class ProgramOutputSink:
         self.bin = ""
         # video pipeline
         self.bin += """
-                video-mix.
+                video-{source}.
                 ! {vcaps}
                 ! videoconvert
                 ! queue

--- a/voctocore/lib/program_output.py
+++ b/voctocore/lib/program_output.py
@@ -29,6 +29,7 @@ class ProgramOutputSink:
         self.bin += """
                 video-mix.
                 ! {vcaps}
+                ! videoconvert
                 ! queue
                     max-size-time=3000000000
                     name=queue-mux-video-localui


### PR DESCRIPTION
1. Improve compatibility with outputs needing a specific format, such as kmssink
2. Allow configuring source for program out (e.g., blinded or preview)