### PR TITLE
replace python3-sdnotify with vocto.sd_notify, use in voctogui

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,6 @@ Depends: gstreamer1.0-plugins-bad,
     python3-gi,
     gir1.2-gstreamer-1.0,
     gir1.2-gst-plugins-base-1.0,
-    python3-sdnotify,
     gstreamer1.0-gl,
     gstreamer1.0-pulseaudio
 Suggests: gstreamer1.0-vaapi,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "numpy<2.0",
     "scipy>=1.15.2",
     "scipy-stubs>=1.15.2.1",
-    "sdnotify>=0.3.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -203,12 +203,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sdnotify"
-version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/d8/9fdc36b2a912bf78106de4b3f0de3891ff8f369e7a6f80be842b8b0b6bd5/sdnotify-0.3.2.tar.gz", hash = "sha256:73977fc746b36cc41184dd43c3fe81323e7b8b06c2bb0826c4f59a20c56bb9f1", size = 2459 }
-
-[[package]]
 name = "typing-extensions"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -225,7 +219,6 @@ dependencies = [
     { name = "numpy" },
     { name = "scipy" },
     { name = "scipy-stubs" },
-    { name = "sdnotify" },
 ]
 
 [package.dev-dependencies]
@@ -241,7 +234,6 @@ requires-dist = [
     { name = "numpy", specifier = "<2.0" },
     { name = "scipy", specifier = ">=1.15.2" },
     { name = "scipy-stubs", specifier = ">=1.15.2.1" },
-    { name = "sdnotify", specifier = ">=0.3.2" },
 ]
 
 [package.metadata.requires-dev]

--- a/vocto/sd_notify.py
+++ b/vocto/sd_notify.py
@@ -1,0 +1,45 @@
+from os import environ
+import socket
+from logging import getLogger
+
+class SystemdNotify:
+    def __init__(self):
+        self.log = getLogger('SystemdNotify')
+
+        addr = environ.get('NOTIFY_SOCKET')
+        self.log.debug(f'{addr=}')
+        if not addr:
+            self.log.info('SD_NOTIFY not available')
+            self.socket = None
+            return
+
+        self.log.info('SD_NOTIFY support enabled')
+        self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        if addr[0] == '@':
+            addr = '\0' + addr[1:]
+        self.socket.connect(addr)
+
+    def _send(self, msg):
+        if not self.socket:
+            # It's fine if we don't have a socket, that just means this
+            # software was started without systemds 'Type=notify'
+            self.log.debug(f'_send({msg!r}) called, but socket is not available')
+            return
+
+        self.log.info(msg)
+        self.socket.sendall((msg.strip() + '\n').encode())
+
+    def ready(self):
+        self._send('READY=1')
+
+    def reloading(self):
+        self._send('RELOADING=1')
+
+    def stopping(self):
+        self._send('STOPPING=1')
+
+    def status(self, msg):
+        self._send(f'STATUS={msg}')
+
+
+sd_notify = SystemdNotify()

--- a/voctocore/README.md
+++ b/voctocore/README.md
@@ -117,7 +117,7 @@ git checkout voctomix2
 ### 1.4.2. Requirements
 
 ````bash
-sudo apt install gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools libgstreamer1.0-0 gstreamer1.0-x python3 python3-gi gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 python3-sdnotify python3-scipy gstreamer1.0-gl gstreamer1.0-pulseaudio
+sudo apt install gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools libgstreamer1.0-0 gstreamer1.0-x python3 python3-gi gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 python3-scipy gstreamer1.0-gl gstreamer1.0-pulseaudio
 ````
 
 ### 1.4.3. For vaapi en/decoding

--- a/voctocore/__main__.py
+++ b/voctocore/__main__.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 import gi
-import sdnotify
 import signal
 import logging
 import sys
 
 from vocto.debug import gst_log_messages
+from vocto.sd_notify import sd_notify
 
 # import GStreamer and GLib-Helper classes
 gi.require_version('Gst', '1.0')
@@ -53,7 +53,9 @@ class Voctocore(object):
     def run(self):
         self.log.info('Running. Waiting for connections....')
         try:
+            sd_notify.ready()
             self.mainloop.run()
+            sd_notify.stopping()
         except KeyboardInterrupt:
             self.log.info('Terminated via Ctrl-C')
 
@@ -95,11 +97,6 @@ def main():
     # init main-class and main-loop
     logging.debug('initializing Voctocore')
     voctocore = Voctocore()
-
-    # Inform systemd that we are ready
-    # for use with the notify service type
-    n = sdnotify.SystemdNotifier()
-    n.notify("READY=1")
 
     logging.debug('running Voctocore')
     voctocore.run()

--- a/voctocore/lib/controlserver.py
+++ b/voctocore/lib/controlserver.py
@@ -9,6 +9,7 @@ from voctocore.lib.response import NotifyResponse
 from voctocore.lib.tcpmulticonnection import TCPMultiConnection
 
 from vocto.port import Port
+from vocto.sd_notify import sd_notify
 
 
 class ControlServer(TCPMultiConnection):
@@ -29,6 +30,11 @@ class ControlServer(TCPMultiConnection):
         self.on_loop_active = False
 
         self.commands = ControlServerCommands(pipeline)
+
+    def _log_num_connections(self):
+        # Overwrite method of TCPMultiConnection to add status information to sd_notify
+        self.log.info(f'Now {self.num_connections()} Receiver(s) connected')
+        sd_notify.status(f'{self.num_connections()} receiver(s) connected to ControlServer')
 
     def on_accepted(self, conn, addr):
         '''Asynchronous connection listener.

--- a/voctocore/lib/tcpmulticonnection.py
+++ b/voctocore/lib/tcpmulticonnection.py
@@ -46,6 +46,10 @@ class TCPMultiConnection(metaclass=ABCMeta):
     def num_connections(self) -> int:
         return len(self.currentConnections)
 
+    def _log_num_connections(self):
+        # lives in its own method so we can overwrite it in children
+        self.log.info(f'Now {self.num_connections()} Receiver(s) connected')
+
     def is_input(self) -> bool:
         return False
 
@@ -57,8 +61,7 @@ class TCPMultiConnection(metaclass=ABCMeta):
                       addr[0], addr[1], conn.fileno())
 
         self.currentConnections[conn] = Queue()
-        self.log.info('Now %u Receiver(s) connected',
-                      len(self.currentConnections))
+        self._log_num_connections()
 
         self.on_accepted(conn, addr)
 
@@ -68,8 +71,7 @@ class TCPMultiConnection(metaclass=ABCMeta):
         if conn in self.currentConnections:
             conn.close()
             del(self.currentConnections[conn])
-        self.log.info('Now %u Receiver connected',
-                      len(self.currentConnections))
+        self._log_num_connections()
 
     @abstractmethod
     def on_accepted(self, conn: socket.socket, addr: tuple[str, int]):

--- a/voctogui/__main__.py
+++ b/voctogui/__main__.py
@@ -13,6 +13,7 @@ import sys
 import os
 
 from vocto.debug import gst_log_messages
+from vocto.sd_notify import sd_notify
 
 # check min-version
 minGst = (1, 5)
@@ -87,7 +88,9 @@ class Voctogui(object):
 
         try:
             self.log.info('Running.')
+            sd_notify.ready()
             Gtk.main()
+            sd_notify.stopping()
             self.log.info('Connection lost. Exiting.')
         except KeyboardInterrupt:
             self.log.info('Terminated via Ctrl-C')


### PR DESCRIPTION
This also adds some status information to systemd, allowing users to see what voctocore is doing without needing to dig through the logs.

Implements #365