### PR TITLE
Bugfix/safe config parser

### DIFF
--- a/README-TRANSITIONS.md
+++ b/README-TRANSITIONS.md
@@ -525,7 +525,7 @@ This generates a B-Spline transition from composite `pip` to composite `sidebysi
 
 ```python
   from transitions import Composites, Transitions, L, T, R, B
-  from configparser import SafeConfigParser
+  from configparser import ConfigParser
   from out_of_scope import update_my_compositor
 
   # set frame size
@@ -533,7 +533,7 @@ This generates a B-Spline transition from composite `pip` to composite `sidebysi
   # set frames per second
   fps = 25
   # load INI files
-  config = SafeConfigParser()
+  config = ConfigParser()
   config.read(filename)
   # read composites config section
   composites = Composites.configure(config.itemc('composites'), size)

--- a/example-scripts/ffmpeg/record-all-audio-streams.py
+++ b/example-scripts/ffmpeg/record-all-audio-streams.py
@@ -5,7 +5,7 @@ import json
 import shlex
 import subprocess
 import logging
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger('record-all-audio-streams')
@@ -35,9 +35,9 @@ def getlist(self, section, option):
     return [x.strip() for x in self.get(section, option).split(',')]
 
 
-SafeConfigParser.getlist = getlist
+ConfigParser.getlist = getlist
 
-config = SafeConfigParser()
+config = ConfigParser()
 config.read_dict(server_config)
 
 sources = config.getlist('mix', 'sources')

--- a/example-scripts/voctomidi/lib/config.py
+++ b/example-scripts/voctomidi/lib/config.py
@@ -1,5 +1,5 @@
 import os.path
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 
 __all__ = ['get_config']
 
@@ -19,7 +19,7 @@ def get_config(filename=None):
     if filename is not None:
         files.append(filename)
 
-    Config = SafeConfigParser()
+    Config = ConfigParser()
     Config.read(files)
 
     return Config

--- a/voctocore/test-transition.py
+++ b/voctocore/test-transition.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # type: ignore
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 from vocto.transitions import Composites, Transitions, L, T, R, B, X, Y
 from PIL import Image, ImageDraw, ImageFont
 # for integer maximum size
@@ -74,7 +74,7 @@ def read_config(filename=None):
     if not filename:
         filename = Args.config
     # load INI files
-    config = SafeConfigParser()
+    config = ConfigParser()
     config.read(filename)
     if Args.size:
         r = re.match(


### PR DESCRIPTION
did a search/replace on SafeConfigParser / ConfigParser

because 
SafeConfigParser out:

voctomix/example-scripts/voctopanel$ python3 lib/config.py 
/home/carl/src/voctomix/example-scripts/voctopanel/lib/config.py:15: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in Python 3.12. Use ConfigParser directly instead.

Also my vim stripped some trailing spaces.  you get that for free.