### PR TITLE
Better support for OSX (videotoolbox + voctogui)

### DIFF
--- a/vocto/video_codecs.py
+++ b/vocto/video_codecs.py
@@ -58,6 +58,18 @@ cpu_decoders = {
                 ! mpeg2dec"""
 }
 
+videotoolbox_encoders = {
+    'h264': 'vtenc_h264 realtime=true allow-frame-reordering=false',
+    'h265': 'vtenc_h265 realtime=true allow-frame-reordering=false',
+}
+
+videotoolbox_decoders = {
+    'h264': """ video/x-h264
+                ! h264parse ! vtdec""",
+    'h265': """ video/x-hevc
+                ! h265parse ! vtdec""",
+}
+
 
 def construct_video_encoder_pipeline(config: VocConfigParser, section: str) -> str:
     encoder = config.getVideoEncoder(section)
@@ -101,6 +113,12 @@ def construct_video_encoder_pipeline(config: VocConfigParser, section: str) -> s
                         ! videoscale
                         ! {encoder}
                         """.format(encoder=cpu_encoders[codec])
+
+    elif encoder == 'videotoolbox':
+        pipeline += """ ! videorate
+                        ! videoscale
+                        ! {encoder}
+                        """.format(encoder=videotoolbox_encoders[codec])
     else:
         log.error("Unknown video encoder '{}'.".format(encoder))
         sys.exit(-1)
@@ -125,6 +143,8 @@ def construct_video_decoder_pipeline(config: VocConfigParser, section: str) -> s
         return vaapi_decoders[codec]
     elif decoder == 'cpu':
         return cpu_decoders[codec]
+    elif decoder == 'videotoolbox':
+        return videotoolbox_decoders[codec]
     else:
         log.error("Unknown video decoder '{}'.".format(decoder))
         exit(-1)

--- a/voctogui/default-config.ini
+++ b/voctogui/default-config.ini
@@ -14,6 +14,9 @@ width=320
 # Use OpenGL - most performant
 #system=gl
 
+# gtk - use this if you have osx
+#system=gtk
+
 # Use XVideo - oldschool
 #system=xv
 

--- a/voctogui/lib/videodisplay.py
+++ b/voctogui/lib/videodisplay.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 
-from gi.repository import Gst, Gdk
+from gi.repository import Gst, Gdk, Gtk
 
 from voctogui.lib.args import Args
 from voctogui.lib.config import Config
@@ -100,7 +100,11 @@ class VideoDisplay(object):
             pipe += """ ! vaapisink
                             name=imagesink-{name}
                         """.format(name=name)
-
+        elif videosystem == 'gtk':
+            pipe += """ ! gtksink
+                            name=imagesink-{name}
+                            sync=false
+                        """.format(name=name)
         else:
             raise Exception(
                 'Invalid Videodisplay-System configured: %s' % videosystem
@@ -146,6 +150,38 @@ class VideoDisplay(object):
 
         self.pipeline.use_clock(Clock)
 
+        # glvideosink is broken on OSX for many years and many attempts have been tried to fix it.
+        # https://discourse.gstreamer.org/t/trying-to-fix-broken-for-4-years-cocoa-implementation-of-glimagesink-on-macos/4600
+        #
+        # Replacing the video drawing area with a gtk widget, rewiring the properies since they are only set on initialisation.
+        # I have not found a better or cleaner way to do this that works on OSX - fspijkerman
+        if videosystem == 'gtk':
+            imagesink_elem = self.pipeline.get_by_name('imagesink-{name}'.format(name=self.name))
+            gtk_widget = imagesink_elem.props.widget
+
+            w, h = self.video_drawing_area.get_size_request()
+            if w > 0 or h > 0:
+                gtk_widget.set_size_request(w, h)
+
+            parent = self.video_drawing_area.get_parent()
+            if isinstance(parent, Gtk.Box):
+                children = parent.get_children()
+                position = children.index(self.video_drawing_area)
+                expand  = parent.child_get_property(self.video_drawing_area, 'expand')
+                fill    = parent.child_get_property(self.video_drawing_area, 'fill')
+                padding = parent.child_get_property(self.video_drawing_area, 'padding')
+                parent.remove(self.video_drawing_area)
+                parent.pack_start(gtk_widget, expand=expand, fill=fill, padding=padding)
+                parent.reorder_child(gtk_widget, position)
+            else:
+                parent.remove(self.video_drawing_area)
+                parent.add(gtk_widget)
+
+            gtk_widget.set_hexpand(self.video_drawing_area.get_hexpand())
+            gtk_widget.set_vexpand(self.video_drawing_area.get_vexpand())
+            gtk_widget.show()
+            self.video_drawing_area = gtk_widget
+
         self.video_drawing_area.add_events(
             Gdk.EventMask.KEY_PRESS_MASK | Gdk.EventMask.KEY_RELEASE_MASK)
         self.video_drawing_area.connect("realize", self.on_realize)
@@ -161,9 +197,14 @@ class VideoDisplay(object):
     def on_realize(self, win):
         self.imagesink = self.pipeline.get_by_name(
             'imagesink-{name}'.format(name=self.name))
-        self.xid = self.video_drawing_area.get_property('window').get_xid()
 
-        self.log.debug('Realized Drawing-Area with xid %u', self.xid)
+        if Config.getVideoSystem() == 'gtk':
+            self.xid = None
+            self.log.debug('Realized gtksink widget (no XID needed)')
+        else:
+            self.xid = self.video_drawing_area.get_property('window').get_xid()
+            self.log.debug('Realized Drawing-Area with xid %u', self.xid)
+
         self.video_drawing_area.realize()
 
         self.log.info("Launching Display-Pipeline")
@@ -172,9 +213,10 @@ class VideoDisplay(object):
     def on_syncmsg(self, bus, msg):
         if type(msg) == Gst.Message and self.imagesink:
             if msg.get_structure().get_name() == "prepare-window-handle":
-                self.log.info(
-                    'Setting imagesink window-handle to 0x%x', self.xid)
-                self.imagesink.set_window_handle(self.xid)
+                if self.xid is not None:
+                    self.log.info(
+                        'Setting imagesink window-handle to 0x%x', self.xid)
+                    self.imagesink.set_window_handle(self.xid)
 
     def on_error(self, bus, message):
         (error, debug) = message.parse_error()

--- a/voctogui/ui/voctogui.ui
+++ b/voctogui/ui/voctogui.ui
@@ -112,6 +112,8 @@
                     <property name="label-xalign">0</property>
                     <property name="shadow-type">none</property>
                     <property name="obey-child">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
                     <child>
                       <object class="GtkDrawingArea" id="video_main">
                         <property name="width-request">100</property>
@@ -124,7 +126,7 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
+                    <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>


### PR DESCRIPTION
* Added support for videotoolbox (osx)
* Hacky way to use gtk to get voctogui working on osx
* Replaced older mpeg2dec => avdec_mpeg2video
* Changed the .ui to allow expanding the widget (does not get it inherited when replaced runtime) 

This also resolves #360
 
I have not been able to test this on Linux. @Kunsi (you asked me to remind u)
