### PR TITLE
Deprecation libmpeg2 since gst 1.28

### DIFF
--- a/vocto/video_codecs.py
+++ b/vocto/video_codecs.py
@@ -31,10 +31,15 @@ v4l2_encoders = {
 }
 
 cpu_encoders = {
-    'jpeg': "jpegenc",
-    'h264': "x264enc",
-    'mpeg2': "mpeg2enc"
+    'jpeg': 'jpegenc',
+    'h264': 'x264enc',
 }
+
+# Deprecation mpeg2enc, https://gstreamer.freedesktop.org/releases/1.28/
+if Gst.version() < (1, 28):
+    cpu_encoders['mpeg2'] = 'mpeg2enc'
+else:
+    cpu_encoders['mpeg2'] = 'avenc_mpeg2video'
 
 if Gst.version() < (1, 8):
     vaapi_decoders = {
@@ -53,10 +58,15 @@ cpu_decoders = {
                 ! h264parse ! avdec_h264""",
     'jpeg': """ image/jpeg
                 ! jpegdec""",
-    'mpeg2': """video/mpeg
-                    mpegversion=2
-                ! mpeg2dec"""
 }
+
+# Deprecation mpeg2dec, https://gstreamer.freedesktop.org/releases/1.28/
+if Gst.version() < (1, 28):
+    cpu_decoders['mpeg2'] = """ video/mpeg,mpegversion=2
+        ! mpeg2dec"""
+else:
+    cpu_decoders['mpeg2'] = """ video/mpeg,mpegversion=2
+        ! avdec_mpeg2video"""
 
 
 def construct_video_encoder_pipeline(config: VocConfigParser, section: str) -> str:

--- a/voctocore/lib/sources/filesource.py
+++ b/voctocore/lib/sources/filesource.py
@@ -62,11 +62,14 @@ class FileSource(AVSource):
         return """
               file-{name}.
             ! mpegvideoparse
-            ! mpeg2dec
+            ! {decoder}
             ! videoconvert
             ! videorate
             ! videoscale
-            """.format(name=self.name)
+            """.format(
+                name=self.name,
+                decoder='mpeg2dec' if Gst.version() < (1,28) else 'avdec_mpeg2video',
+            )
 
     def build_audioport(self):
         return """


### PR DESCRIPTION
Since GStreamer 1.28, the `mpeg2dec` and `mpeg2enc` elements provided by libmpeg2 have been deprecated. This change replaces them with FFmpeg-based alternatives: `avdec_mpeg2video` for decoding and `avenc_mpeg2video` for encoding.

See the GStreamer 1.28 release notes for details:
https://gstreamer.freedesktop.org/releases/1.28/